### PR TITLE
Fix: package VSIX with dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
       run: npm run compile
     
     - name: Package VSIX
-      run: npx @vscode/vsce package --no-dependencies
-    
+      run: npx @vscode/vsce package
+
     - name: Upload VSIX artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
       run: npm run compile
     
     - name: Package VSIX
-      run: npx @vscode/vsce package --no-dependencies
-    
+      run: npx @vscode/vsce package
+
     - name: Get version from tag
       id: version
       run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
@@ -64,7 +64,7 @@ jobs:
       run: npm run compile
     
     - name: Publish to VS Code Marketplace
-      run: npx @vscode/vsce publish --no-dependencies
+      run: npx @vscode/vsce publish
       env:
         VSCE_PAT: ${{ secrets.VSCE_PAT }}
       continue-on-error: true
@@ -90,7 +90,7 @@ jobs:
       run: npm run compile
     
     - name: Publish to Open VSX
-      run: npx ovsx publish --no-dependencies
+      run: npx ovsx publish
       env:
         OVSX_PAT: ${{ secrets.OVSX_PAT }}
       continue-on-error: true


### PR DESCRIPTION
Removes \--no-dependencies\ flag from all vsce package/publish commands so the VSIX includes required npm dependencies (uuid, micromatch, etc).