### PR TITLE
fix: correct license in package.json from MIT to GPL-3.0-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Orchestrate parallel GitHub Copilot agents in isolated git worktrees with DAG-based execution, secure MCP integration via nonce-authenticated IPC, real-time process monitoring, and automated 7-phase pipelines (merge → prechecks → work → commit → postchecks → merge-back → cleanup).",
   "version": "0.6.0",
   "publisher": "JeromyStatia",
-  "license": "MIT",
+  "license": "GPL-3.0-only",
   "icon": "media/copilot-icon.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
LICENSE file and GitHub repo both specify GPL-3.0. The package.json incorrectly stated MIT. This corrects it to \GPL-3.0-only\ (SPDX identifier).