### PR TITLE
v0.9.4: Dependency update (qs 6.14.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the Copilot Orchestrator extension will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4] - 2026-02-13
+
+### Changed
+- **Dependencies**: Bump `qs` from 6.14.1 to 6.14.2 (bug fixes for `arrayLimit` handling in parse/combine/merge)
+
 ## [0.9.3] - 2026-02-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-copilot-orchestrator",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-copilot-orchestrator",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "license": "GPL-3.0-only",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-copilot-orchestrator",
   "displayName": "Copilot Orchestrator",
   "description": "Orchestrate parallel GitHub Copilot agents in isolated git worktrees with DAG-based execution, secure MCP integration via nonce-authenticated IPC, real-time process monitoring, and automated 7-phase pipelines (merge → prechecks → work → commit → postchecks → merge-back → cleanup).",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "publisher": "JeromyStatia",
   "license": "GPL-3.0-only",
   "icon": "media/copilot-icon.png",


### PR DESCRIPTION
## Changes
- Bump \qs\ from 6.14.1 to 6.14.2 (incorporates dependabot PR #30)
- Version bump to 0.9.4
- CHANGELOG updated

### qs 6.14.2 fixes
- \parse\: mark overflow objects for indexed notation exceeding \rrayLimit\
- \rrayLimit\ means max count, not max index, in \combine\/\merge\/\parseArrayValue\
- \parse\: throw on \rrayLimit\ exceeded with indexed notation when \	hrowOnLimitExceeded\ is true
- \parse\: enforce \rrayLimit\ on comma-parsed values

Closes #30