### PR TITLE
fix: make target branch creation fatal on resume (v0.11.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Copilot Orchestrator extension will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.16] - 2026-02-16
+
+### Fixed
+- **Centralized target branch setup in execution pump**: Branch creation and `.gitignore` commit now happen in the pump before any nodes execute, ensuring the same codepath runs for both paused-then-resumed and immediately-started (`startPaused: false`) plans. Previously, branch setup only ran in `resume()`, so non-paused plans would proceed to RI merge with a missing local ref.
+- **`branchReady` flag**: Plans now track whether target branch setup is complete. The pump skips plans whose branch hasn't been created yet, and persists the flag across restarts so setup isn't repeated.
+
 ## [0.11.15] - 2026-02-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-copilot-orchestrator",
-  "version": "0.11.15",
+  "version": "0.11.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-copilot-orchestrator",
-      "version": "0.11.15",
+      "version": "0.11.16",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@types/markdown-it": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-copilot-orchestrator",
   "displayName": "Copilot Orchestrator",
   "description": "Orchestrate parallel GitHub Copilot agents in isolated git worktrees with DAG-based execution, secure MCP integration via nonce-authenticated IPC, real-time process monitoring, and automated 7-phase pipelines (merge → prechecks → work → commit → postchecks → merge-back → cleanup).",
-  "version": "0.11.15",
+  "version": "0.11.16",
   "publisher": "JeromyStatia",
   "license": "GPL-3.0-only",
   "icon": "media/copilot-icon.png",

--- a/src/plan/persistence.ts
+++ b/src/plan/persistence.ts
@@ -52,6 +52,7 @@ interface SerializedPlan {
   maxParallel: number;
   workSummary?: WorkSummary;
   isPaused?: boolean;
+  branchReady?: boolean;
 }
 
 interface SerializedNode {
@@ -346,6 +347,7 @@ export class PlanPersistence {
       maxParallel: plan.maxParallel,
       workSummary: plan.workSummary,
       isPaused: plan.isPaused,
+      branchReady: plan.branchReady,
     };
   }
   
@@ -441,6 +443,7 @@ export class PlanPersistence {
       maxParallel: data.maxParallel,
       workSummary: data.workSummary,
       isPaused: data.isPaused,
+      branchReady: data.branchReady,
     };
   }
   

--- a/src/plan/runner.ts
+++ b/src/plan/runner.ts
@@ -129,6 +129,13 @@ export class PlanRunner extends EventEmitter {
     this._engine = new JobExecutionEngine(state, this._nodeManager, log, deps.git);
     this._pump = new ExecutionPump(state, log, (plan, sm, node) => {
       this._engine.executeJobNode(plan, sm, node);
+    }, async (plan) => {
+      await this._lifecycle.ensureTargetBranch(plan);
+      try {
+        await this._lifecycle.commitGitignoreEntries(plan);
+      } catch (e: any) {
+        log.warn(`Failed to commit .gitignore entries (continuing): ${e.message}`);
+      }
     });
 
     this._wireEvents();

--- a/src/plan/types/plan.ts
+++ b/src/plan/types/plan.ts
@@ -456,6 +456,9 @@ export interface PlanInstance {
   
   /** Whether the plan is paused (no new work scheduled, worktrees preserved) */
   isPaused?: boolean;
+
+  /** Whether the target branch has been created and .gitignore committed */
+  branchReady?: boolean;
   
   /** Aggregated work summary */
   workSummary?: WorkSummary;


### PR DESCRIPTION
## Problem

\nsureTargetBranchAndGitignore\ was catching **all** errors (including branch creation failures) and continuing with a warning. This meant if the target branch ref couldn't be created locally, the plan would proceed to RI merge, which would then fail with 'git can't find it' when trying to resolve the target branch ref.

## Fix

Split \nsureTargetBranchAndGitignore\ into two methods:
- **\nsureTargetBranch\** (critical) — creates the local branch ref. Throws on failure, causing resume to reject.
- **\commitGitignoreEntries\** (best-effort) — checks out the target branch and commits \.gitignore\ entries. Warns and continues on failure.

All branch operations are local-only. Push to remote only happens if the \pushOnSuccess\ setting is enabled.

## Testing
- 2475 tests passing (1 new test for gitignore-fail-continues path)
- Updated existing test: branch creation failure now rejects resume instead of continuing