### PR TITLE
fix: sanitize XML/tool-invocation artifacts from work spec instructions

### DIFF
--- a/src/plan/types/specs.ts
+++ b/src/plan/types/specs.ts
@@ -412,6 +412,26 @@ export function normalizeWorkSpec(spec: WorkSpec | undefined): ProcessSpec | She
     raw.errorAction = raw.error_action;
     delete raw.error_action;
   }
+
+  // Sanitize XML/tool-invocation artifacts that LLMs sometimes inject into fields.
+  // Common: </invoke>, </invoke>, </function_call>, etc.
+  if (raw.type === 'agent' && typeof raw.instructions === 'string') {
+    raw.instructions = stripXmlArtifacts(raw.instructions);
+  }
+  if (raw.type === 'shell' && typeof raw.command === 'string') {
+    raw.command = stripXmlArtifacts(raw.command);
+  }
   
   return spec;
+}
+
+/** Strip XML/tool-invocation artifacts injected by LLMs into spec fields. */
+function stripXmlArtifacts(text: string): string {
+  const xmlPattern = /<\/?(?:invoke|antml:invoke|function_call|tool_call|antml:function_calls)[^>]*>/gi;
+  const cleaned = text.replace(xmlPattern, '').trim();
+  if (cleaned !== text.trim()) {
+    // Best-effort log — console.warn is always available in extension host context
+    try { console.warn('[normalizeWorkSpec] Stripped XML/tool-invocation artifacts from spec text'); } catch { /* */ }
+  }
+  return cleaned;
 }


### PR DESCRIPTION
LLMs sometimes inject XML closing tags into work spec fields when creating plans via MCP tools. Added stripXmlArtifacts() to normalizeWorkSpec() to automatically clean these before execution.