### PR TITLE
hotfix: finalize must not cancel nodes when rebuilding state machine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-copilot-orchestrator",
-  "version": "0.15.81",
+  "version": "0.15.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-copilot-orchestrator",
-      "version": "0.15.81",
+      "version": "0.15.7",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@types/markdown-it": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-copilot-orchestrator",
   "displayName": "Copilot Orchestrator",
   "description": "Orchestrate parallel GitHub Copilot agents in isolated git worktrees with DAG-based execution, secure MCP integration via nonce-authenticated IPC, real-time process monitoring, and automated 7-phase pipelines (merge → prechecks → work → commit → postchecks → merge-back → cleanup).",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "publisher": "JeromyStatia",
   "license": "GPL-3.0-only",
   "icon": "media/copilot-icon.png",

--- a/src/plan/finalizePlanHelper.ts
+++ b/src/plan/finalizePlanHelper.ts
@@ -76,9 +76,16 @@ export async function finalizePlanInRunner(
     });
   }
 
-  // 4. Delete old registration and re-register to rebuild state machine with new nodes
-  planRunner.delete(planId);
-  (planRunner as any).registerPlan(existingPlan);
+  // 4. Remove old registration (without canceling/deleting!) and re-register
+  //    to rebuild the state machine with the finalized nodes.
+  //    IMPORTANT: Do NOT call planRunner.delete() — that cancels all nodes and
+  //    writes a tombstone. Instead, remove from internal maps directly.
+  const runner = planRunner as any;
+  if (runner._state?.plans) { runner._state.plans.delete(planId); }
+  if (runner._state?.stateMachines) { runner._state.stateMachines.delete(planId); }
+  if (runner._lifecycle?.state?.plans) { runner._lifecycle.state.plans.delete(planId); }
+  if (runner._lifecycle?.state?.stateMachines) { runner._lifecycle.state.stateMachines.delete(planId); }
+  runner.registerPlan(existingPlan);
 
   // 5. If not paused, resume to kick off execution
   if (!shouldPause) {

--- a/src/plan/types/specs.ts
+++ b/src/plan/types/specs.ts
@@ -412,6 +412,24 @@ export function normalizeWorkSpec(spec: WorkSpec | undefined): ProcessSpec | She
     raw.errorAction = raw.error_action;
     delete raw.error_action;
   }
+
+  // Sanitize XML/tool-invocation artifacts that LLMs sometimes inject into fields.
+  if (raw.type === 'agent' && typeof raw.instructions === 'string') {
+    raw.instructions = stripXmlArtifacts(raw.instructions);
+  }
+  if (raw.type === 'shell' && typeof raw.command === 'string') {
+    raw.command = stripXmlArtifacts(raw.command);
+  }
   
   return spec;
+}
+
+/** Strip XML/tool-invocation artifacts injected by LLMs into spec fields. */
+function stripXmlArtifacts(text: string): string {
+  const xmlPattern = /<\/?(?:invoke|antml:invoke|function_call|tool_call|antml:function_calls)[^>]*>/gi;
+  const cleaned = text.replace(xmlPattern, '').trim();
+  if (cleaned !== text.trim()) {
+    try { console.warn('[normalizeWorkSpec] Stripped XML/tool-invocation artifacts from spec text'); } catch { /* */ }
+  }
+  return cleaned;
 }

--- a/src/test/unit/mcp/scaffoldHandlers.unit.test.ts
+++ b/src/test/unit/mcp/scaffoldHandlers.unit.test.ts
@@ -36,11 +36,13 @@ suite('MCP Scaffold Handlers', () => {
         events: {
           emitPlanUpdated: sandbox.stub(),
         },
+        plans: new Map(),
         stateMachineFactory: sandbox.stub(),
         stateMachines: new Map(),
       },
       _lifecycle: {
         setupStateMachineListeners: sandbox.stub(),
+        state: { plans: new Map(), stateMachines: new Map() },
       },
       enqueue: sandbox.stub(),
       registerPlan: sandbox.stub(),
@@ -442,8 +444,7 @@ suite('MCP Scaffold Handlers', () => {
 
       await handleFinalizePlan(args, mockContext);
 
-      // finalizePlanInRunner calls delete + registerPlan which triggers planCreated event internally
-      assert.ok(mockPlanRunner.delete.calledWith('test-plan'));
+      // finalizePlanInRunner removes from maps + registerPlan
       assert.ok(mockPlanRunner.registerPlan.calledOnce);
     });
 
@@ -481,8 +482,7 @@ suite('MCP Scaffold Handlers', () => {
       const result = await handleFinalizePlan(args, mockContext);
 
       assert.strictEqual(result.success, true);
-      // State machine is rebuilt via delete + registerPlan
-      assert.ok(mockPlanRunner.delete.calledWith('test-plan'));
+      // State machine is rebuilt via map removal + registerPlan
       assert.ok(mockPlanRunner.registerPlan.calledOnce);
     });
 

--- a/src/test/unit/plan/finalizePlanHelper.unit.test.ts
+++ b/src/test/unit/plan/finalizePlanHelper.unit.test.ts
@@ -56,13 +56,18 @@ suite('finalizePlanHelper', () => {
     const getSpy = sandbox.stub();
     getSpy.onFirstCall().returns(plan);      // first call: check scaffolding
     getSpy.onSecondCall().returns(plan);      // after re-register: return updated plan
-    const planRunner = { get: getSpy, delete: deleteSpy, registerPlan: registerSpy, resume: resumeSpy } as any;
+    const planRunner = {
+      get: getSpy,
+      registerPlan: registerSpy,
+      resume: resumeSpy,
+      _state: { plans: new Map([['p1', plan]]), stateMachines: new Map() },
+      _lifecycle: { state: { plans: new Map([['p1', plan]]), stateMachines: new Map() } },
+    } as any;
     const planRepo = { finalize: sandbox.stub().resolves(finalized) } as any;
 
     const result = await finalizePlanInRunner('p1', planRunner, planRepo, { startPaused: false });
     assert.strictEqual(result.success, true);
     assert.ok(planRepo.finalize.calledOnce);
-    assert.ok(deleteSpy.calledOnce);
     assert.ok(registerSpy.calledOnce);
     assert.ok(resumeSpy.calledOnce);
     assert.strictEqual((plan.spec as any).status, 'pending');


### PR DESCRIPTION
## Critical Bug

Calling \inalizePlanInRunner()\ immediately cancels all plan nodes because \planRunner.delete()\ internally calls \cancel()\ before removing from maps. Every finalized plan appears as 'canceled' with 0 attempts.

## Fix

Replace \planRunner.delete()\ with direct map removal (\plans.delete\, \stateMachines.delete\)  no cancel, no tombstone, no resource cleanup. Then \egisterPlan()\ creates a fresh state machine.

Also includes XML artifact sanitization in \
ormalizeWorkSpec()\.

## Impact

- **Finalize & Start** button in plan detail UI
- **\inalize_copilot_plan\** MCP tool
- **\orchestrator.bulkFinalize\** command
- All plans finalized since v0.15.5 were silently canceled