### PR TITLE
fix: auto-heal setup-phase shell failures + gate contextPressure on enable flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-copilot-orchestrator",
-  "version": "0.16.5",
+  "version": "0.16.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-copilot-orchestrator",
-      "version": "0.16.5",
+      "version": "0.16.9",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@types/markdown-it": "^14.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-copilot-orchestrator",
   "displayName": "Copilot Orchestrator",
   "description": "Orchestrate parallel GitHub Copilot agents in isolated git worktrees with DAG-based execution, secure MCP integration via nonce-authenticated IPC, real-time process monitoring, and automated 7-phase pipelines (merge → prechecks → work → commit → postchecks → merge-back → cleanup).",
-  "version": "0.16.5",
+  "version": "0.16.9",
   "publisher": "JeromyStatia",
   "license": "GPL-3.0-only",
   "icon": "media/copilot-icon.png",
@@ -457,8 +457,8 @@
         },
         "copilotOrchestrator.contextPressure.enabled": {
           "type": "boolean",
-          "default": true,
-          "description": "Enable automatic context pressure detection and job splitting. When enabled, the orchestrator monitors agent token usage and creates sub-jobs when context pressure is detected."
+          "default": false,
+          "description": "Enable automatic context pressure detection and job splitting. When enabled, the orchestrator monitors agent token usage and creates sub-jobs when context pressure is detected. Default is false — enable only after validating the splitter behavior on your workload."
         },
         "copilotOrchestrator.contextPressure.elevatedThreshold": {
           "type": "number",

--- a/src/agent/handlers/contextPressureHandler.ts
+++ b/src/agent/handlers/contextPressureHandler.ts
@@ -164,13 +164,22 @@ export class ContextPressureHandler implements IOutputHandler {
  * Factory that creates {@link ContextPressureHandler} instances for copilot processes.
  *
  * Returns `undefined` when planId or nodeId is missing (e.g. model discovery,
- * CLI check — not a plan job).
+ * CLI check — not a plan job), or when the context-pressure feature is
+ * disabled (no global checkpoint manager registered).
  */
 export const ContextPressureHandlerFactory: IOutputHandlerFactory = {
   name: 'context-pressure',
   processFilter: ['copilot'],
   create: (ctx: HandlerContext): IOutputHandler | undefined => {
     if (!ctx.planId || !ctx.nodeId) {
+      return undefined;
+    }
+    // Feature gate: planInitialization only registers the global checkpoint
+    // manager when copilotOrchestrator.contextPressure.enabled is true. When
+    // it's absent we short-circuit the entire detection path — no monitor is
+    // created, no token tracking, no sentinel writes, no DAG reshape. This
+    // makes the setting fully authoritative: OFF means OFF end-to-end.
+    if (!getCheckpointManager()) {
       return undefined;
     }
     const monitor = new ContextPressureMonitor(ctx.planId, ctx.nodeId, 1, 'work');

--- a/src/agent/handlers/statsHandler.ts
+++ b/src/agent/handlers/statsHandler.ts
@@ -122,6 +122,53 @@ export class StatsHandler implements IOutputHandler {
       return;
     }
 
+    // CLI v1.0.34 compact format — "Changes   +N -M" (no "Total code changes:" prefix)
+    const compactChangesMatch = content.match(/^Changes\s+\+(\d+)\s+-(\d+)\s*$/i);
+    if (compactChangesMatch) {
+      this._codeChanges = {
+        linesAdded: parseInt(compactChangesMatch[1], 10),
+        linesRemoved: parseInt(compactChangesMatch[2], 10),
+      };
+      this._hasAnyMetric = true;
+      if (!this._statsStartedAt) { this._statsStartedAt = Date.now(); }
+      this._parsingModels = false;
+      return;
+    }
+
+    // CLI v1.0.34 compact format — "Requests  N Premium (Xm Ys)"
+    const compactRequestsMatch = content.match(/^Requests\s+([\d.]+)\s+Premium\s+\(([^)]+)\)\s*$/i);
+    if (compactRequestsMatch) {
+      this._premiumRequests = parseFloat(compactRequestsMatch[1]);
+      this._apiTimeSeconds = parseDuration(compactRequestsMatch[2].trim());
+      this._hasAnyMetric = true;
+      if (!this._statsStartedAt) { this._statsStartedAt = Date.now(); }
+      this._parsingModels = false;
+      return;
+    }
+
+    // CLI v1.0.34 compact format — "Tokens    ↑ X • ↓ Y • Z (cached)"
+    // Bullet may be Unicode '•' (U+2022) or ASCII fallback; arrows are '↑' / '↓'.
+    const compactTokensMatch = content.match(
+      /^Tokens\s+[↑\^]\s*([\d.]+[km]?)\s*[•·*]\s*[↓v]\s*([\d.]+[km]?)(?:\s*[•·*]\s*([\d.]+[km]?)\s*\(cached\))?\s*$/i
+    );
+    if (compactTokensMatch) {
+      const inputTokens = parseTokenCount(compactTokensMatch[1]);
+      const outputTokens = parseTokenCount(compactTokensMatch[2]);
+      const cached = compactTokensMatch[3] ? parseTokenCount(compactTokensMatch[3]) : undefined;
+      // Synthesize a single-model breakdown entry so downstream code (which derives
+      // tokenUsage from modelBreakdown) keeps working even when no per-model lines
+      // appear (the v1.0.34 compact format omits them on short runs).
+      if (!this._modelBreakdown || this._modelBreakdown.length === 0) {
+        const entry: ModelUsageBreakdown = { model: 'unknown', inputTokens, outputTokens };
+        if (cached !== undefined) { entry.cachedTokens = cached; }
+        this._modelBreakdown = [entry];
+      }
+      this._hasAnyMetric = true;
+      if (!this._statsStartedAt) { this._statsStartedAt = Date.now(); }
+      this._parsingModels = false;
+      return;
+    }
+
     // Breakdown by AI model:
     if (/Breakdown by AI model:/i.test(content)) {
       this._parsingModels = true;

--- a/src/agent/modelDiscovery.ts
+++ b/src/agent/modelDiscovery.ts
@@ -99,6 +99,7 @@ const KNOWN_MODEL_TIERS: Record<string, ModelInfo['tier']> = {
   'claude-opus-4.5':        'premium',   // 3x+
   'claude-opus-4.6':        'premium',   // 3x
   'claude-opus-4.6-fast':   'premium',   // 3x (lower latency variant)
+  'claude-opus-4.6-1m':     'premium',   // 3x+ (1M-token context window — prefer for massive-context tasks)
 
   // ── OpenAI ─────────────────────────────────────────────────────────
   'gpt-4.1':                'standard',  // 1x
@@ -451,6 +452,14 @@ export async function suggestModel(taskType: 'fast' | 'standard' | 'premium', de
 
   const candidates = result.models.filter(m => m.tier === taskType);
   if (candidates.length > 0) {
+    // For premium-tier suggestions, prefer large-context variants (e.g. 1m) so
+    // context-heavy work doesn't get truncated. Heuristic: any model id whose
+    // suffix indicates an extended context window (e.g. '-1m', '-200k', '-2m')
+    // is preferred over the base model.
+    if (taskType === 'premium') {
+      const largeContext = candidates.find(m => /-(\d+)(k|m)\b/i.test(m.id));
+      if (largeContext) { return largeContext; }
+    }
     return candidates[0];
   }
 

--- a/src/core/planInitialization.ts
+++ b/src/core/planInitialization.ts
@@ -129,22 +129,37 @@ export async function initializePlanRunner(
   const planRepository = container.resolve<import('../interfaces/IPlanRepository').IPlanRepository>(Tokens.IPlanRepository);
   planRunner.setPlanRepository(planRepository);
 
-  // Wire context pressure services (checkpoint detection and DAG reshape)
-  const { DefaultCheckpointManager } = await import('../plan/analysis/checkpointManager');
-  const { DefaultJobSplitter } = await import('../plan/analysis/jobSplitter');
+  // Wire context pressure services (checkpoint detection and DAG reshape).
+  //
+  // GATED on copilotOrchestrator.contextPressure.enabled (default: false). When
+  // disabled we skip wiring the checkpoint manager and job splitter onto the
+  // plan runner entirely, so the executionEngine's split branch (which requires
+  // both `checkpointManager` and `jobSplitter` on its state) is short-circuited
+  // even if a stale `checkpoint-manifest.json` exists in a worktree (e.g.
+  // committed during an earlier run when the feature was enabled).
+  //
+  // We also skip registering the global checkpoint manager so the
+  // ContextPressureHandler factory's `if (!mgr)` branch turns the entire
+  // detection flow into a no-op. The runner instructions and hook installer
+  // are gated on the same setting in copilotCliRunner.ts.
   const fileSystem = container.resolve<import('../interfaces/IFileSystem').IFileSystem>(Tokens.IFileSystem);
   const configProvider = container.resolve<import('../interfaces/IConfigProvider').IConfigProvider>(Tokens.IConfigProvider);
-  // Reuse a single CheckpointManager instance for both the plan runner and the
-  // global pressure registry, so the ContextPressureHandler and the runner observe
-  // the same checkpoint state (avoids divergent behavior between the two paths).
-  const checkpointManager = new DefaultCheckpointManager(fileSystem);
-  planRunner.setCheckpointManager(checkpointManager);
-  planRunner.setJobSplitter(new DefaultJobSplitter(configProvider));
+  const contextPressureEnabled = configProvider.getConfig<boolean>(
+    'copilotOrchestrator.contextPressure', 'enabled', false
+  );
+  if (contextPressureEnabled) {
+    const { DefaultCheckpointManager } = await import('../plan/analysis/checkpointManager');
+    const { DefaultJobSplitter } = await import('../plan/analysis/jobSplitter');
+    // Reuse a single CheckpointManager instance for both the plan runner and the
+    // global pressure registry, so the ContextPressureHandler and the runner observe
+    // the same checkpoint state (avoids divergent behavior between the two paths).
+    const checkpointManager = new DefaultCheckpointManager(fileSystem);
+    planRunner.setCheckpointManager(checkpointManager);
+    planRunner.setJobSplitter(new DefaultJobSplitter(configProvider));
 
-  // Also expose the checkpoint manager to the global pressure registry so the
-  // ContextPressureHandler can write the sentinel when level transitions to critical.
-  const { setCheckpointManager: setGlobalCheckpointManager } = await import('../plan/analysis/pressureMonitorRegistry');
-  setGlobalCheckpointManager(checkpointManager);
+    const { setCheckpointManager: setGlobalCheckpointManager } = await import('../plan/analysis/pressureMonitorRegistry');
+    setGlobalCheckpointManager(checkpointManager);
+  }
 
   // Register PlanRecovery service now that PlanRunner exists
   // (IPlanRecovery needs IPlanRunner, so it must be registered after PlanRunner is created)

--- a/src/git/core/merge.ts
+++ b/src/git/core/merge.ts
@@ -292,8 +292,9 @@ export async function merge(options: MergeOptions): Promise<MergeResult> {
     return { success: true, hasConflicts: false, conflictFiles: [] };
   }
   
-  // Check if it's a conflict
-  if (result.stderr.includes('CONFLICT') || result.stdout.includes('CONFLICT')) {
+  // Check if it's a conflict (including pre-existing unmerged files blocking the merge)
+  const combinedOutput = `${result.stdout}\n${result.stderr}`;
+  if (combinedOutput.includes('CONFLICT') || combinedOutput.includes('unmerged files')) {
     const conflicts = await listConflicts(cwd);
     log?.(`[merge] ⚠ Merge conflicts in ${conflicts.length} file(s)`);
     return { 

--- a/src/mcp/handlers/plan/bulkUpdateJobsHandler.ts
+++ b/src/mcp/handlers/plan/bulkUpdateJobsHandler.ts
@@ -83,11 +83,16 @@ export async function handleBulkUpdatePlanJobs(args: any, ctx: PlanHandlerContex
       if (!match) { continue; }
     }
 
-    // Skip terminal/running jobs
+    // Skip jobs whose work spec must not be mutated:
+    //  - running:   in-flight; mutating now would corrupt the active execution
+    //  - succeeded: work is already done; updating spec would be misleading
+    //  - canceled:  terminal; no future execution
+    // ALLOW failed and blocked: these are pre-execution states for retry, and
+    // updating their spec (e.g., model/effort) before retry is the primary use case.
     const state = plan.nodeStates.get(nodeId);
     if (state) {
       const status = state.status;
-      if (status === 'running' || status === 'succeeded' || status === 'failed' || status === 'blocked' || status === 'canceled') {
+      if (status === 'running' || status === 'succeeded' || status === 'canceled') {
         skipped.push({ id: jobNode.producerId ?? nodeId, reason: `status=${status}` });
         continue;
       }

--- a/src/mcp/tools/jobTools.ts
+++ b/src/mcp/tools/jobTools.ts
@@ -250,7 +250,8 @@ NOT BULK-SAFE (use update_copilot_plan_job individually):
 - instructions, contextFiles, allowedFolders, allowedUrls
 
 If jobIds is omitted, ALL agent-type jobs in the plan are updated.
-Running/terminal jobs are skipped automatically.`,
+Skipped automatically: running, succeeded, and canceled jobs.
+Included: pending, ready, failed, and blocked jobs (failed/blocked are the primary use case — update model/effort before retry).`,
       inputSchema: {
         type: 'object',
         properties: {

--- a/src/plan/executionEngine.ts
+++ b/src/plan/executionEngine.ts
@@ -616,12 +616,18 @@ export class JobExecutionEngine {
           // skipped; later phases (including commit) run normally.
           const failedPhase = result.failedPhase || 'work';
           const isHealablePhase = ['setup', 'prechecks', 'work', 'postchecks'].includes(failedPhase);
-          // Resolve the failed phase's work spec: prefer inline, fall back to disk (finalized plans)
+          // Resolve the failed phase's work spec.
+          // PRIORITY: result.failedWorkSpec — set by phase executors when they have the
+          // exact spec in hand (notably setup, where the failing spec is a worktreeInit
+          // entry and is NOT the same as node.work). Fall back to inline node specs,
+          // then to disk specs (for finalized plans where prechecks/postchecks may be
+          // serialized separately).
           const failedWorkSpecInline = failedPhase === 'prechecks' ? node.prechecks
             : failedPhase === 'postchecks' ? node.postchecks
+            : failedPhase === 'setup' ? undefined  // setup has no inline spec on the node
             : node.work;
-          let failedWorkSpec = failedWorkSpecInline;
-          if (!failedWorkSpec && plan.definition) {
+          let failedWorkSpec: WorkSpec | undefined = result.failedWorkSpec ?? failedWorkSpecInline;
+          if (!failedWorkSpec && plan.definition && failedPhase !== 'setup') {
             try {
               failedWorkSpec = failedPhase === 'prechecks'
                 ? await plan.definition.getPrechecksSpec(node.id)
@@ -664,7 +670,7 @@ export class JobExecutionEngine {
           }
           
           const healCount = (() => {
-            const v = nodeState.autoHealAttempted?.[failedPhase as 'prechecks' | 'work' | 'postchecks'];
+            const v = nodeState.autoHealAttempted?.[failedPhase as 'setup' | 'prechecks' | 'work' | 'postchecks'];
             if (v === true) {return 1;} // backward compat
             return typeof v === 'number' ? v : 0;
           })();
@@ -693,7 +699,7 @@ export class JobExecutionEngine {
             while (currentHealCount < MAX_AUTO_HEAL_PER_PHASE) {
               currentHealCount++;
               if (!nodeState.autoHealAttempted) {nodeState.autoHealAttempted = {};}
-              nodeState.autoHealAttempted[failedPhase as 'prechecks' | 'work' | 'postchecks'] = currentHealCount;
+              nodeState.autoHealAttempted[failedPhase as 'setup' | 'prechecks' | 'work' | 'postchecks'] = currentHealCount;
             
             if (isAgentWork && wasExternallyKilled) {
               // Agent was interrupted - retry with same spec (don't swap to different agent spec)
@@ -1194,7 +1200,7 @@ export class JobExecutionEngine {
 
               // Track as a heal attempt for the budget
               if (!nodeState.autoHealAttempted) { nodeState.autoHealAttempted = {}; }
-              nodeState.autoHealAttempted[failedPhase as 'prechecks' | 'work' | 'postchecks'] = healCount + 1;
+              nodeState.autoHealAttempted[failedPhase as 'setup' | 'prechecks' | 'work' | 'postchecks'] = healCount + 1;
 
               // Reset state for retry
               nodeState.error = undefined;
@@ -1402,9 +1408,20 @@ export class JobExecutionEngine {
         // If the agent checkpointed due to context pressure, reshape the DAG with
         // fan-out sub-jobs and a fan-in validation job before transitioning to succeeded.
         //
-        // Feature flag: skip all context pressure logic when disabled via env var
-        const contextPressureDisabled = process.env.ORCH_CONTEXT_PRESSURE === 'false';
-        const hasCheckpointManifest = !contextPressureDisabled
+        // Gated on TWO conditions (defense in depth):
+        //   1. ORCH_CONTEXT_PRESSURE env var is not 'false' (test/runtime override).
+        //   2. copilotOrchestrator.contextPressure.enabled setting is true (user-facing).
+        // Composition skips wiring `checkpointManager`/`jobSplitter` onto the runner
+        // when the setting is false, so the truthy checks below are normally enough;
+        // we re-check the config here so a stale manifest left in a worktree (e.g.
+        // committed during an earlier run when the feature was enabled) cannot
+        // resurrect the split path on plans run with the feature disabled.
+        const contextPressureDisabledEnv = process.env.ORCH_CONTEXT_PRESSURE === 'false';
+        const contextPressureEnabledSetting = this.state.configManager.getConfig<boolean>(
+          'copilotOrchestrator.contextPressure', 'enabled', false,
+        );
+        const hasCheckpointManifest = !contextPressureDisabledEnv
+          && contextPressureEnabledSetting
           && nodeState.worktreePath
           && this.state.checkpointManager
           && this.state.jobSplitter
@@ -1443,9 +1460,16 @@ export class JobExecutionEngine {
 
               // Compute the checkpoint group path so sub-jobs and fan-in are
               // registered in the plan's group hierarchy for status tracking.
+              // The plan group system treats '/' as a nesting delimiter, so any
+              // '/' in the node name (common when names mirror file paths like
+              // "Solution foundation AiOrchestrator.sln, Directory.Build.props")
+              // would explode into many empty nested group boxes in the UI.
+              // Sanitize by replacing '/' with '-' in the name segment so the
+              // checkpoint group adds exactly one level under the parent group.
+              const safeNameSegment = node.name.replace(/\//g, '-');
               const cpGroupPath = node.group
-                ? `${node.group}/${node.name}`
-                : node.name;
+                ? `${node.group}/${safeNameSegment}`
+                : safeNameSegment;
 
               // Fan-out: create sub-jobs (work only, NO postchecks).
               // IMPORTANT: Capture original downstream dependents BEFORE adding sub-jobs,

--- a/src/plan/executionEngine.ts
+++ b/src/plan/executionEngine.ts
@@ -615,7 +615,7 @@ export class JobExecutionEngine {
           // and resuming from that phase. Earlier phases that passed are
           // skipped; later phases (including commit) run normally.
           const failedPhase = result.failedPhase || 'work';
-          const isHealablePhase = ['setup', 'prechecks', 'work', 'postchecks'].includes(failedPhase);
+          const isHealablePhase = ['setup', 'merge-fi', 'prechecks', 'work', 'postchecks'].includes(failedPhase);
           // Resolve the failed phase's work spec.
           // PRIORITY: result.failedWorkSpec — set by phase executors when they have the
           // exact spec in hand (notably setup, where the failing spec is a worktreeInit
@@ -669,8 +669,12 @@ export class JobExecutionEngine {
             nodeState.resumeFromPhase = result.overrideResumeFromPhase;
           }
           
+          // Track heal budget under the phase that will actually be re-executed.
+          // When overrideResumeFromPhase is set (e.g. commit→work), track under the
+          // override target so the budget is correctly consumed and reset.
+          const healBudgetPhase = (result.overrideResumeFromPhase ?? failedPhase) as 'setup' | 'merge-fi' | 'prechecks' | 'work' | 'postchecks';
           const healCount = (() => {
-            const v = nodeState.autoHealAttempted?.[failedPhase as 'setup' | 'prechecks' | 'work' | 'postchecks'];
+            const v = nodeState.autoHealAttempted?.[healBudgetPhase];
             if (v === true) {return 1;} // backward compat
             return typeof v === 'number' ? v : 0;
           })();
@@ -683,8 +687,10 @@ export class JobExecutionEngine {
           // 2. Agent work that was externally killed (retry same agent)
           // 3. NOT blocked by phase-level noAutoHeal
           // 4. Under per-phase heal budget
+          // Infrastructure phases (merge-fi) have no work spec — they are always eligible for auto-heal
+          const isInfrastructurePhase = failedPhase === 'merge-fi';
           const shouldAttemptAutoRetry = isHealablePhase && autoHealEnabled && !phaseAlreadyHealed && !phaseNoAutoHeal &&
-            (isNonAgentWork || (isAgentWork && wasExternallyKilled));
+            (isInfrastructurePhase || isNonAgentWork || (isAgentWork && wasExternallyKilled));
           
           this.log.info(`Auto-retry shouldAttempt=${shouldAttemptAutoRetry}: isHealablePhase=${isHealablePhase}, autoHealEnabled=${autoHealEnabled}, phaseAlreadyHealed=${phaseAlreadyHealed}, phaseNoAutoHeal=${phaseNoAutoHeal}, isNonAgentWork=${isNonAgentWork}, isAgentWork=${isAgentWork}`, {
             planId: plan.id,
@@ -699,7 +705,7 @@ export class JobExecutionEngine {
             while (currentHealCount < MAX_AUTO_HEAL_PER_PHASE) {
               currentHealCount++;
               if (!nodeState.autoHealAttempted) {nodeState.autoHealAttempted = {};}
-              nodeState.autoHealAttempted[failedPhase as 'setup' | 'prechecks' | 'work' | 'postchecks'] = currentHealCount;
+              nodeState.autoHealAttempted[healBudgetPhase] = currentHealCount;
             
             if (isAgentWork && wasExternallyKilled) {
               // Agent was interrupted - retry with same spec (don't swap to different agent spec)

--- a/src/plan/executor.ts
+++ b/src/plan/executor.ts
@@ -21,7 +21,7 @@ import type { IFileSystem } from '../interfaces/IFileSystem';
 import type { ICopilotRunner } from '../interfaces/ICopilotRunner';
 import { aggregateMetrics } from './metricsAggregator';
 import type { IEvidenceValidator } from '../interfaces';
-import type { PhaseContext } from '../interfaces/IPhaseExecutor';
+import type { PhaseContext, PhaseResult } from '../interfaces/IPhaseExecutor';
 import { ensureOrchestratorDirs } from '../core';
 import {
   SetupPhaseExecutor,
@@ -270,20 +270,32 @@ export class DefaultJobExecutor implements JobExecutor {
           initCtx.workSpec = initSpec;
           initCtx.env = mergeEnv(initSpec);
           const initResult = await new WorkPhaseExecutor(phaseDeps()).execute(initCtx);
+          // Capture sessionId on success OR failure — agent-driven worktreeInit
+          // specs may report a copilot session even when the spec ultimately fails;
+          // dropping it here would break later session-based diagnostics/auto-heal.
+          if (initResult.copilotSessionId) { capturedSessionId = initResult.copilotSessionId; }
           if (!initResult.success) {
             context.phaseTiming![context.phaseTiming!.length - 1].endedAt = Date.now();
             this.logEntry(executionKey, 'setup', 'error', `worktreeInit [${i + 1}] failed: ${initResult.error}`);
             this.logEntry(executionKey, 'setup', 'info', '========== SETUP SECTION END ==========');
             stepStatuses.setup = 'failed'; context.onStepStatusChange?.('setup', 'failed');
-            return { success: false, error: `Worktree init failed: ${initResult.error}`, stepStatuses, failedPhase: 'setup', metrics: capturedMetrics, phaseMetrics: pmk(''), pid: execution.process?.pid, phaseTiming: context.phaseTiming };
+            // Apply the init spec's onFailure config (noAutoHeal/message/resumeFromPhase)
+            // so worktreeInit specs can opt out of auto-heal or surface user-facing
+            // messages, mirroring how prechecks/work/postchecks handle failures.
+            return this.applyFailureConfig(
+              { success: false, error: `Worktree init failed: ${initResult.error}`, stepStatuses, failedPhase: 'setup', failedWorkSpec: initSpec, exitCode: initResult.exitCode, metrics: capturedMetrics, phaseMetrics: pmk(''), pid: execution.process?.pid, noAutoHeal: initResult.noAutoHeal, failureMessage: initResult.failureMessage, overrideResumeFromPhase: initResult.overrideResumeFromPhase, phaseTiming: context.phaseTiming, copilotSessionId: capturedSessionId },
+              initSpec,
+            );
           }
-          if (initResult.copilotSessionId) { capturedSessionId = initResult.copilotSessionId; }
         }
         if (initSpecs.length > 0) { this.logEntry(executionKey, 'setup', 'info', `All ${initSpecs.length} worktreeInit spec(s) completed successfully`); }
 
         context.phaseTiming![context.phaseTiming!.length - 1].endedAt = Date.now();
         this.logEntry(executionKey, 'setup', 'info', '========== SETUP SECTION END ==========');
-        if (!r.success) { stepStatuses.setup = 'failed'; context.onStepStatusChange?.('setup', 'failed'); return { success: false, error: `Setup failed: ${r.error}`, stepStatuses, failedPhase: 'setup', metrics: capturedMetrics, phaseMetrics: pmk(''), pid: execution.process?.pid, phaseTiming: context.phaseTiming }; }
+        // Note: we don't re-check `!r.success` here — the early return at the top
+        // of this block (right after `SetupPhaseExecutor.execute`) already handles
+        // setup-phase failure. `r` isn't reassigned in the worktreeInit loop, so
+        // re-checking it would be dead code.
         stepStatuses.setup = 'success'; context.onStepStatusChange?.('setup', 'success');
       }
       if (execution.aborted) {return { success: false, error: 'Execution canceled', stepStatuses, pid: execution.process?.pid, phaseTiming: context.phaseTiming };}
@@ -353,6 +365,7 @@ export class DefaultJobExecutor implements JobExecutor {
       // ---- COMMIT ----
       const workWasSkipped = skip('work') || stepStatuses.work === 'skipped';
       let pendingCommitFailure: string | null = null;
+      let pendingCommitOverrideResume: PhaseResult['overrideResumeFromPhase'] | undefined;
       context.onProgress?.('Committing changes'); context.onStepStatusChange?.('commit', 'running');
       this.logEntry(executionKey, 'commit', 'info', '========== COMMIT SECTION START ==========');
       const phaseStartCommit = Date.now();
@@ -364,8 +377,8 @@ export class DefaultJobExecutor implements JobExecutor {
       if (cr.reviewMetrics) { phaseMetrics['commit'] = cr.reviewMetrics; capturedMetrics = capturedMetrics ? aggregateMetrics([capturedMetrics, cr.reviewMetrics]) : cr.reviewMetrics; }
       if (!cr.success) {
         if (workWasSkipped && context.resumeFromPhase !== 'commit') { this.logEntry(executionKey, 'commit', 'info', 'Commit found no evidence, but work was skipped (resuming from later phase). Succeeding without commit.'); stepStatuses.commit = 'success'; context.onStepStatusChange?.('commit', 'success'); }
-        else if (postchecksSpec_ && !skip('postchecks')) { stepStatuses.commit = 'failed'; context.onStepStatusChange?.('commit', 'failed'); pendingCommitFailure = cr.error ?? 'unknown'; }
-        else { stepStatuses.commit = 'failed'; context.onStepStatusChange?.('commit', 'failed'); return { success: false, error: `Commit failed: ${cr.error}`, stepStatuses, copilotSessionId: capturedSessionId, failedPhase: 'commit', metrics: capturedMetrics, phaseMetrics: pmk(''), pid: execution.process?.pid, phaseTiming: context.phaseTiming }; }
+        else if (postchecksSpec_ && !skip('postchecks')) { stepStatuses.commit = 'failed'; context.onStepStatusChange?.('commit', 'failed'); pendingCommitFailure = cr.error ?? 'unknown'; pendingCommitOverrideResume = cr.overrideResumeFromPhase; }
+        else { stepStatuses.commit = 'failed'; context.onStepStatusChange?.('commit', 'failed'); return { success: false, error: `Commit failed: ${cr.error}`, stepStatuses, copilotSessionId: capturedSessionId, failedPhase: 'commit', metrics: capturedMetrics, phaseMetrics: pmk(''), pid: execution.process?.pid, phaseTiming: context.phaseTiming, overrideResumeFromPhase: cr.overrideResumeFromPhase }; }
       } else { stepStatuses.commit = 'success'; context.onStepStatusChange?.('commit', 'success'); }
 
       // ---- POSTCHECKS ----
@@ -402,7 +415,7 @@ export class DefaultJobExecutor implements JobExecutor {
           stepStatuses.postchecks = 'success'; context.onStepStatusChange?.('postchecks', 'success');
         }
       } else { stepStatuses.postchecks = 'skipped'; context.onStepStatusChange?.('postchecks', 'skipped'); }
-      if (pendingCommitFailure) { return { success: false, error: `Commit failed: ${pendingCommitFailure}`, stepStatuses, copilotSessionId: capturedSessionId, failedPhase: 'commit', metrics: capturedMetrics, phaseMetrics: pmk(''), pid: execution.process?.pid, phaseTiming: context.phaseTiming }; }
+      if (pendingCommitFailure) { return { success: false, error: `Commit failed: ${pendingCommitFailure}`, stepStatuses, copilotSessionId: capturedSessionId, failedPhase: 'commit', metrics: capturedMetrics, phaseMetrics: pmk(''), pid: execution.process?.pid, phaseTiming: context.phaseTiming, overrideResumeFromPhase: pendingCommitOverrideResume }; }
       if (execution.aborted) {return { success: false, error: 'Execution canceled', stepStatuses, copilotSessionId: capturedSessionId, phaseTiming: context.phaseTiming };}
 
       // ---- MERGE-RI ----

--- a/src/plan/nodeManager.ts
+++ b/src/plan/nodeManager.ts
@@ -409,7 +409,10 @@ export class NodeManager {
       if (hasNewWork) delete nodeState.autoHealAttempted['work'];
       if (hasNewPrechecks) delete nodeState.autoHealAttempted['prechecks'];
       if (hasNewPostchecks) delete nodeState.autoHealAttempted['postchecks'];
-      if (options?.clearWorktree) delete nodeState.autoHealAttempted['setup'];
+      if (options?.clearWorktree) {
+        delete nodeState.autoHealAttempted['setup'];
+        delete nodeState.autoHealAttempted['merge-fi'];
+      }
     }
 
     if (shouldResetPhases) {

--- a/src/plan/nodeManager.ts
+++ b/src/plan/nodeManager.ts
@@ -402,11 +402,14 @@ export class NodeManager {
     const failedPhase = nodeState.lastAttempt?.phase;
     const shouldResetPhases = hasNewWork || hasNewPrechecks || options?.clearWorktree;
 
-    // Reset auto-heal budget for phases with new specs so fresh work gets fresh heal attempts
+    // Reset auto-heal budget for phases with new specs so fresh work gets fresh heal attempts.
+    // 'setup' is plan-level (worktreeInit lives on plan.spec, not the node) so it is reset
+    // only when the worktree is cleared — that's the only retry path that re-runs setup.
     if (nodeState.autoHealAttempted) {
       if (hasNewWork) delete nodeState.autoHealAttempted['work'];
       if (hasNewPrechecks) delete nodeState.autoHealAttempted['prechecks'];
       if (hasNewPostchecks) delete nodeState.autoHealAttempted['postchecks'];
+      if (options?.clearWorktree) delete nodeState.autoHealAttempted['setup'];
     }
 
     if (shouldResetPhases) {

--- a/src/plan/phases/commitPhase.ts
+++ b/src/plan/phases/commitPhase.ts
@@ -193,14 +193,14 @@ export class CommitPhaseExecutor implements IPhaseExecutor {
           ctx.logInfo(`AI review: Changes were expected — ${reviewResult.reason}`);
           const error = this.noEvidenceError();
           ctx.logError(error);
-          return { success: false, error, reviewMetrics: reviewResult.metrics };
+          return { success: false, error, reviewMetrics: reviewResult.metrics, overrideResumeFromPhase: 'work' };
         }
       }
 
-      // No evidence — fail
+      // No evidence — fail (retry from work phase via auto-heal)
       const error = this.noEvidenceError();
       ctx.logError(error);
-      return { success: false, error };
+      return { success: false, error, overrideResumeFromPhase: 'work' };
     }
 
     // Stage and commit

--- a/src/plan/phases/workPhase.ts
+++ b/src/plan/phases/workPhase.ts
@@ -146,7 +146,7 @@ export async function runAgent(
   const COMPLEXITY_FILE_COUNT = 6;
   const isExplicitlyTuned = !!spec.model || !!spec.modelTier;
   if (!isExplicitlyTuned && spec.instructions) {
-    const instrBytes = spec.instructions.length;
+    const instrBytes = Buffer.byteLength(spec.instructions, 'utf8');
     // Count "Files to create / modify" entries — heuristic: lines that look like
     // path-ish entries (contain '/' and end with file extension) inside the
     // instructions. Cheap and false-positive tolerant.

--- a/src/plan/phases/workPhase.ts
+++ b/src/plan/phases/workPhase.ts
@@ -137,6 +137,30 @@ export async function runAgent(
   ctx.setStartTime(startTime);
   ctx.logInfo(`Agent instructions: ${spec.instructions}`);
 
+  // Auto-promote complex jobs to a premium tier + high effort when neither model
+  // nor modelTier is explicitly set. Sonnet 4.6 has been observed to give up
+  // (empty assistant message → end_turn) on large multi-file scaffold tasks
+  // (Files-to-create ≥ 6 OR instructions > 4 KB). Bumping to a premium model
+  // with deeper reasoning is the cheapest reliable mitigation.
+  const COMPLEXITY_INSTR_BYTES = 4_000;
+  const COMPLEXITY_FILE_COUNT = 6;
+  const isExplicitlyTuned = !!spec.model || !!spec.modelTier;
+  if (!isExplicitlyTuned && spec.instructions) {
+    const instrBytes = spec.instructions.length;
+    // Count "Files to create / modify" entries — heuristic: lines that look like
+    // path-ish entries (contain '/' and end with file extension) inside the
+    // instructions. Cheap and false-positive tolerant.
+    const fileLikeLines = (spec.instructions.match(/^[\s\-*`]*[\w./_-]+\/[\w./_-]+\.[a-z0-9]+\s*$/gim) ?? []).length;
+    if (instrBytes >= COMPLEXITY_INSTR_BYTES || fileLikeLines >= COMPLEXITY_FILE_COUNT) {
+      // Mutate a copy so we never alter the persisted spec.
+      spec = { ...spec, modelTier: 'premium', effort: spec.effort ?? 'high' };
+      ctx.logInfo(
+        `Auto-promoted complex agent job: instrBytes=${instrBytes}, fileLikeLines=${fileLikeLines} ` +
+        `→ modelTier='premium', effort='${spec.effort}'. Set model/modelTier explicitly to opt out.`
+      );
+    }
+  }
+
   // Resolve model from modelTier if model isn't explicitly set
   let resolvedModel = spec.model;
   if (!resolvedModel && spec.modelTier) {
@@ -198,6 +222,25 @@ export async function runAgent(
     if (result.metrics) { metrics = { ...result.metrics, durationMs }; }
     else { metrics = { durationMs }; }
     if (result.success) {
+      // No-op exit detector: the CLI reports success but produced no work.
+      // Without this, the commit phase eventually fails with "No work evidence
+      // produced" — wasting the diagnostic signal and a full retry cycle.
+      // Tripping conditions (all must hold):
+      //   - The node does NOT declare expectsNoChanges (legitimate verify-only)
+      //   - Stats reported zero adds AND zero removes (so we have a metric to trust)
+      //   - Run lasted long enough that the model had a real chance to do work
+      //     (avoids tripping on fast verification turns or transient rejections)
+      const NOOP_MIN_DURATION_MS = 60_000;
+      const expectsNoChanges = !!ctx.node.expectsNoChanges;
+      const codeChanges = result.metrics?.codeChanges;
+      const isZeroChange = codeChanges && codeChanges.linesAdded === 0 && codeChanges.linesRemoved === 0;
+      if (!expectsNoChanges && isZeroChange && durationMs >= NOOP_MIN_DURATION_MS) {
+        const error = `Agent exited with no-op turn — zero code changes after ${Math.round(durationMs / 1000)}s. ` +
+          `The model gave up without producing output (likely research paralysis). ` +
+          `Retry with a higher tier or narrower instructions.`;
+        ctx.logError(`No-op detected: ${error}`);
+        return { success: false, error, copilotSessionId: result.sessionId, exitCode: result.exitCode, metrics };
+      }
       ctx.logInfo('Agent completed successfully');
       if (result.sessionId) {ctx.logInfo(`Captured session ID: ${result.sessionId}`);}
       return { success: true, copilotSessionId: result.sessionId, metrics };

--- a/src/plan/types/plan.ts
+++ b/src/plan/types/plan.ts
@@ -299,7 +299,7 @@ export interface NodeExecutionState {
    * Each value is the number of heal attempts for that phase.
    * Backwards-compatible: `true` is treated as 1 when reading.
    */
-  autoHealAttempted?: Partial<Record<'setup' | 'prechecks' | 'work' | 'postchecks', boolean | number>>;
+  autoHealAttempted?: Partial<Record<'setup' | 'merge-fi' | 'prechecks' | 'work' | 'postchecks', boolean | number>>;
   
   /**
    * Details about the last execution attempt (for retry context).

--- a/src/plan/types/plan.ts
+++ b/src/plan/types/plan.ts
@@ -299,7 +299,7 @@ export interface NodeExecutionState {
    * Each value is the number of heal attempts for that phase.
    * Backwards-compatible: `true` is treated as 1 when reading.
    */
-  autoHealAttempted?: Partial<Record<'prechecks' | 'work' | 'postchecks', boolean | number>>;
+  autoHealAttempted?: Partial<Record<'setup' | 'prechecks' | 'work' | 'postchecks', boolean | number>>;
   
   /**
    * Details about the last execution attempt (for retry context).
@@ -816,6 +816,16 @@ export interface JobExecutionResult {
   copilotSessionId?: string;
   /** Which phase failed (for retry context) */
   failedPhase?: 'prechecks' | 'work' | 'commit' | 'postchecks' | 'merge-fi' | 'merge-ri' | 'setup' | 'cleanup';
+  /**
+   * The actual WorkSpec that failed within the failed phase.
+   * Critical for the `setup` phase, where the failing spec is a `worktreeInit`
+   * entry from `plan.spec.worktreeInit` and is NOT the same as `node.work`.
+   * The auto-heal gating logic in executionEngine inspects this to decide
+   * whether to swap to an AI agent (when the failed spec is shell/process)
+   * or retry the same agent (when externally killed).
+   * Phase executors should set this whenever they have the spec in hand.
+   */
+  failedWorkSpec?: WorkSpec;
   /** Exit code from failed process */
   exitCode?: number;
   /** Agent execution metrics (token usage, duration, turns, tool calls) */

--- a/src/test/unit/agent/handlers/contextPressureHandler.unit.test.ts
+++ b/src/test/unit/agent/handlers/contextPressureHandler.unit.test.ts
@@ -198,10 +198,20 @@ suite('ContextPressureHandlerFactory', () => {
 
   setup(() => {
     sandbox = sinon.createSandbox();
+    // The factory short-circuits when no global checkpoint manager is
+    // registered (feature gate: copilotOrchestrator.contextPressure.enabled).
+    // Register a stub manager so the existing factory tests exercise the
+    // active-feature path.
+    pressureMonitorRegistry.setCheckpointManager({
+      writeSentinel: sinon.stub().resolves(),
+      manifestExists: sinon.stub().resolves(false),
+      readManifest: sinon.stub().resolves(undefined),
+    } as any);
   });
 
   teardown(() => {
     sandbox.restore();
+    pressureMonitorRegistry.setCheckpointManager(undefined as any);
   });
 
   suite('metadata', () => {
@@ -282,6 +292,26 @@ suite('ContextPressureHandlerFactory', () => {
       const state = result.monitor.getState();
       assert.strictEqual(state.planId, 'plan-1');
       assert.strictEqual(state.nodeId, 'node-1');
+    });
+
+    // Feature gate: when copilotOrchestrator.contextPressure.enabled is false,
+    // planInitialization skips registering the global checkpoint manager. The
+    // factory must short-circuit in that state so no monitor is created and
+    // no token tracking, sentinel writes, or DAG reshapes occur.
+    test('returns undefined when feature is disabled (no checkpoint manager registered)', () => {
+      pressureMonitorRegistry.setCheckpointManager(undefined as any);
+      const registerStub = sandbox.stub(pressureMonitorRegistry, 'registerMonitor');
+
+      const result = ContextPressureHandlerFactory.create({
+        processLabel: 'copilot',
+        planId: 'plan-1',
+        nodeId: 'node-1',
+      });
+
+      assert.strictEqual(result, undefined,
+        'factory must skip handler creation when feature is disabled');
+      assert.strictEqual(registerStub.called, false,
+        'no monitor should be registered when feature is disabled');
     });
   });
 });

--- a/src/test/unit/agent/handlers/statsHandler.unit.test.ts
+++ b/src/test/unit/agent/handlers/statsHandler.unit.test.ts
@@ -494,4 +494,74 @@ suite('StatsHandler', () => {
       assert.strictEqual(metrics.premiumRequests, 3);
     });
   });
+
+  // =========================================================================
+  // CLI v1.0.34 compact stats format
+  // =========================================================================
+  suite('CLI v1.0.34 compact format', () => {
+    test('parses "Changes   +N -M" line', () => {
+      const handler = new StatsHandler();
+      feedLine(handler, 'Changes   +12 -5');
+      const metrics = handler.getMetrics();
+      assert.ok(metrics);
+      assert.deepStrictEqual(metrics.codeChanges, { linesAdded: 12, linesRemoved: 5 });
+    });
+
+    test('parses "Changes   +0 -0" (the no-op case we need to detect)', () => {
+      const handler = new StatsHandler();
+      feedLine(handler, 'Changes   +0 -0');
+      const metrics = handler.getMetrics();
+      assert.ok(metrics);
+      assert.deepStrictEqual(metrics.codeChanges, { linesAdded: 0, linesRemoved: 0 });
+    });
+
+    test('parses "Requests  N Premium (Xm Ys)" line', () => {
+      const handler = new StatsHandler();
+      feedLine(handler, 'Requests  1 Premium (5m 19s)');
+      const metrics = handler.getMetrics();
+      assert.ok(metrics);
+      assert.strictEqual(metrics.premiumRequests, 1);
+      assert.strictEqual(metrics.apiTimeSeconds, 5 * 60 + 19);
+    });
+
+    test('parses "Tokens    ↑ X • ↓ Y • Z (cached)" line with unicode bullet', () => {
+      const handler = new StatsHandler();
+      feedLine(handler, 'Tokens    \u2191 589.7k \u2022 \u2193 21.0k \u2022 543.0k (cached)');
+      const metrics = handler.getMetrics();
+      assert.ok(metrics);
+      assert.ok(metrics.modelBreakdown);
+      assert.strictEqual(metrics.modelBreakdown![0].inputTokens, 589700);
+      assert.strictEqual(metrics.modelBreakdown![0].outputTokens, 21000);
+      assert.strictEqual(metrics.modelBreakdown![0].cachedTokens, 543000);
+    });
+
+    test('parses all three v1.0.34 compact lines together (the user-reported sample)', () => {
+      const handler = new StatsHandler();
+      feedLine(handler, 'Changes   +0 -0');
+      feedLine(handler, 'Requests  1 Premium (5m 19s)');
+      feedLine(handler, 'Tokens    \u2191 589.7k \u2022 \u2193 21.0k \u2022 543.0k (cached)');
+      const metrics = handler.getMetrics();
+      assert.ok(metrics);
+      assert.deepStrictEqual(metrics.codeChanges, { linesAdded: 0, linesRemoved: 0 });
+      assert.strictEqual(metrics.premiumRequests, 1);
+      assert.strictEqual(metrics.apiTimeSeconds, 319);
+      assert.ok(metrics.modelBreakdown);
+    });
+
+    test('compact "Changes" line strips bracketed log prefix', () => {
+      const handler = new StatsHandler();
+      feedLine(handler, '[copilot] Changes   +3 -1');
+      const metrics = handler.getMetrics();
+      assert.ok(metrics);
+      assert.deepStrictEqual(metrics.codeChanges, { linesAdded: 3, linesRemoved: 1 });
+    });
+
+    test('compact format does not falsely match old "Total code changes:" line', () => {
+      const handler = new StatsHandler();
+      feedLine(handler, 'Total code changes:     +7 -2');
+      const metrics = handler.getMetrics();
+      assert.ok(metrics);
+      assert.deepStrictEqual(metrics.codeChanges, { linesAdded: 7, linesRemoved: 2 });
+    });
+  });
 });

--- a/src/test/unit/agent/modelDiscovery.unit.test.ts
+++ b/src/test/unit/agent/modelDiscovery.unit.test.ts
@@ -243,6 +243,33 @@ suite('Model Discovery - Async Functions', () => {
         assert.ok(suggestion.id);
       }
     });
+
+    test('prefers large-context variant (e.g. -1m) for premium tier', async function () {
+      this.timeout(15000);
+      resetModelCache();
+      // Mock CLI config that lists both regular Opus and the 1m large-context variant
+      const configWithLargeContext = `Configuration Settings:
+
+  \`model\`: AI model to use for Copilot CLI.
+    - "claude-opus-4.6"
+    - "claude-opus-4.6-1m"
+    - "claude-sonnet-4.6"
+`;
+      const localDeps: ModelDiscoveryDeps = {
+        spawner: createMockSpawner({
+          '--help': FAKE_HELP_V1,
+          'help': FAKE_HELP_V1,
+          'help config': configWithLargeContext,
+          'config --help': configWithLargeContext,
+        }),
+      };
+      const suggestion = await suggestModel('premium', localDeps);
+      // When both 200k and 1m premium models are available, the 1m variant must win.
+      if (suggestion) {
+        assert.strictEqual(suggestion.id, 'claude-opus-4.6-1m',
+          `Expected large-context variant to be preferred, got '${suggestion.id}'`);
+      }
+    });
   });
 
   // ==========================================================================
@@ -550,6 +577,13 @@ suite('classifyModel - new model names', () => {
 
   test('classifies claude-opus-4.6-fast as anthropic/claude/premium', () => {
     const result = classifyModel('claude-opus-4.6-fast');
+    assert.strictEqual(result.vendor, 'anthropic');
+    assert.strictEqual(result.family, 'claude');
+    assert.strictEqual(result.tier, 'premium');
+  });
+
+  test('classifies claude-opus-4.6-1m as anthropic/claude/premium (1M context variant)', () => {
+    const result = classifyModel('claude-opus-4.6-1m');
     assert.strictEqual(result.vendor, 'anthropic');
     assert.strictEqual(result.family, 'claude');
     assert.strictEqual(result.tier, 'premium');

--- a/src/test/unit/core/planInitialization.unit.test.ts
+++ b/src/test/unit/core/planInitialization.unit.test.ts
@@ -10,6 +10,9 @@
 import { suite, test, setup, teardown } from 'mocha';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { loadConfiguration } from '../../../core/planInitialization';
 import { IConfigProvider } from '../../../interfaces/IConfigProvider';
 
@@ -855,5 +858,142 @@ suite('initializePlanRunner', () => {
     } catch {
       // Expected in test env
     }
+  });
+
+  // Regression: the ContextPressureHandlerFactory writes the CHECKPOINT_REQUIRED
+  // sentinel via the global checkpoint manager. Before the gate fix that registry
+  // was populated unconditionally, so the handler fired even when the agent had
+  // never been told the checkpoint protocol — leading to synthesized fallback
+  // manifests and empty "Continue the original task" sub-jobs. The gate must
+  // tie the registry write to copilotOrchestrator.contextPressure.enabled.
+  suite('contextPressure.enabled gating', () => {
+    let registry: any;
+
+    setup(() => {
+      // Use the cached module instance — planInitialization uses dynamic
+      // `await import(...)` which returns the cached singleton. Busting the
+      // require cache here would give the test a *different* module instance
+      // than the one written to by initializePlanRunner, causing the
+      // "DOES register" assertion to read undefined even when the production
+      // code correctly registered the manager.
+      registry = require('../../../plan/analysis/pressureMonitorRegistry');
+      // Clear any prior global manager
+      registry.setCheckpointManager(undefined as any);
+    });
+
+    teardown(() => {
+      registry.setCheckpointManager(undefined as any);
+      vscode.workspace.workspaceFolders = undefined;
+    });
+
+    // Per-suite real workspace dir so PlanPersistence's mkdirSync('.orchestrator') succeeds
+    // on POSIX CI runners (where '/test/workspace' is not writable).
+    const tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'orch-init-test-'));
+
+    async function runWithEnabled(enabled: boolean): Promise<{ planRunner?: any; initError?: unknown }> {
+      const { initializePlanRunner } = require('../../../core/planInitialization');
+      const { createContainer } = require('../../../composition');
+      const Tokens = require('../../../core/tokens');
+
+      vscode.workspace.workspaceFolders = [
+        { uri: vscode.Uri.file(tmpWorkspace), name: 'test', index: 0 },
+      ];
+
+      const mockContext = {
+        subscriptions: [] as any[],
+        extensionUri: vscode.Uri.file('/ext'),
+        globalStorageUri: vscode.Uri.file('/storage'),
+        globalState: { get: () => undefined, update: async () => {} },
+      };
+
+      const container = createContainer(mockContext);
+
+      // Stub the IConfigProvider to control the contextPressure.enabled flag
+      const realProvider = container.resolve(Tokens.IConfigProvider);
+      const stubProvider = {
+        ...realProvider,
+        getConfig: <T>(section: string, key: string, defaultValue: T): T => {
+          if (section === 'copilotOrchestrator.contextPressure' && key === 'enabled') {
+            return enabled as unknown as T;
+          }
+          if (typeof realProvider.getConfig === 'function') {
+            return realProvider.getConfig(section, key, defaultValue);
+          }
+          return defaultValue;
+        },
+      };
+      container.registerSingleton(Tokens.IConfigProvider, () => stubProvider);
+
+      try {
+        const result = await initializePlanRunner(mockContext, container);
+        return result;
+      } catch (err) {
+        // Surface init errors so tests don't silently pass on early-bail.
+        return { initError: err };
+      }
+    }
+
+    test('does NOT register global checkpoint manager when disabled (default)', async function() {
+      this.timeout(10000);
+      const result = await runWithEnabled(false);
+      if (result.initError) {
+        assert.fail(`initializePlanRunner threw: ${(result.initError as Error)?.stack || result.initError}`);
+      }
+      assert.ok(result.planRunner, 'expected planRunner to be returned by initializePlanRunner');
+      assert.strictEqual(
+        registry.getCheckpointManager(),
+        undefined,
+        'global checkpoint manager must remain unregistered when contextPressure.enabled is false',
+      );
+    });
+
+    test('DOES register global checkpoint manager when enabled', async function() {
+      this.timeout(10000);
+      const result = await runWithEnabled(true);
+      if (result.initError) {
+        assert.fail(`initializePlanRunner threw: ${(result.initError as Error)?.stack || result.initError}`);
+      }
+      assert.ok(result.planRunner, 'expected planRunner to be returned by initializePlanRunner');
+      assert.ok(
+        registry.getCheckpointManager(),
+        'global checkpoint manager must be registered when contextPressure.enabled is true',
+      );
+    });
+
+    // Regression: even if a stale checkpoint-manifest.json exists in a worktree
+    // (e.g. committed during an earlier run when the feature was enabled), the
+    // runner must not synthesize -sub-N / -fan-in jobs when the user-facing
+    // setting is disabled. Achieved by skipping setCheckpointManager() and
+    // setJobSplitter() on the runner so the executionEngine's split branch
+    // (which requires both on its state) is short-circuited.
+    test('does NOT wire checkpointManager/jobSplitter on runner when disabled', async function() {
+      this.timeout(10000);
+      const { planRunner, initError } = await runWithEnabled(false);
+      if (initError) {
+        assert.fail(`initializePlanRunner threw: ${(initError as Error)?.stack || initError}`);
+      }
+      assert.ok(planRunner, 'expected planRunner to be returned by initializePlanRunner');
+      const state = (planRunner as any)._state;
+      assert.ok(state, 'expected planRunner._state to exist');
+      assert.strictEqual(state.checkpointManager, undefined,
+        'runner.checkpointManager must remain unset when contextPressure.enabled is false');
+      assert.strictEqual(state.jobSplitter, undefined,
+        'runner.jobSplitter must remain unset when contextPressure.enabled is false');
+    });
+
+    test('DOES wire checkpointManager/jobSplitter on runner when enabled', async function() {
+      this.timeout(10000);
+      const { planRunner, initError } = await runWithEnabled(true);
+      if (initError) {
+        assert.fail(`initializePlanRunner threw: ${(initError as Error)?.stack || initError}`);
+      }
+      assert.ok(planRunner, 'expected planRunner to be returned by initializePlanRunner');
+      const state = (planRunner as any)._state;
+      assert.ok(state, 'expected planRunner._state to exist');
+      assert.ok(state.checkpointManager,
+        'runner.checkpointManager must be wired when contextPressure.enabled is true');
+      assert.ok(state.jobSplitter,
+        'runner.jobSplitter must be wired when contextPressure.enabled is true');
+    });
   });
 });

--- a/src/test/unit/core/planInitialization.unit.test.ts
+++ b/src/test/unit/core/planInitialization.unit.test.ts
@@ -881,14 +881,19 @@ suite('initializePlanRunner', () => {
       registry.setCheckpointManager(undefined as any);
     });
 
+    // Per-suite real workspace dir so PlanPersistence's mkdirSync('.orchestrator') succeeds
+    // on POSIX CI runners (where '/test/workspace' is not writable).
+    let tmpWorkspace: string;
+
+    setup(() => {
+      tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'orch-init-test-'));
+    });
+
     teardown(() => {
       registry.setCheckpointManager(undefined as any);
       vscode.workspace.workspaceFolders = undefined;
+      try { fs.rmSync(tmpWorkspace, { recursive: true, force: true }); } catch { /* best-effort */ }
     });
-
-    // Per-suite real workspace dir so PlanPersistence's mkdirSync('.orchestrator') succeeds
-    // on POSIX CI runners (where '/test/workspace' is not writable).
-    const tmpWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'orch-init-test-'));
 
     async function runWithEnabled(enabled: boolean): Promise<{ planRunner?: any; initError?: unknown }> {
       const { initializePlanRunner } = require('../../../core/planInitialization');
@@ -924,8 +929,17 @@ suite('initializePlanRunner', () => {
       };
       container.registerSingleton(Tokens.IConfigProvider, () => stubProvider);
 
+      const git = container.resolve(Tokens.IGitOperations) ?? {
+        repository: { isRepo: async () => true },
+        merge: {},
+        worktree: {},
+      };
+      const debouncer = container.resolve(Tokens.IGitignoreDebouncer) ?? {
+        ensureEntries: async () => {},
+      };
+
       try {
-        const result = await initializePlanRunner(mockContext, container);
+        const result = await initializePlanRunner(mockContext, container, git, debouncer);
         return result;
       } catch (err) {
         // Surface init errors so tests don't silently pass on early-bail.

--- a/src/test/unit/mcp/handlers/plan/bulkUpdateJobsHandler.unit.test.ts
+++ b/src/test/unit/mcp/handlers/plan/bulkUpdateJobsHandler.unit.test.ts
@@ -1,0 +1,224 @@
+import * as assert from 'assert';
+import { suite, test, setup, teardown } from 'mocha';
+import * as sinon from 'sinon';
+import { handleBulkUpdatePlanJobs } from '../../../../../mcp/handlers/plan/bulkUpdateJobsHandler';
+import type { PlanInstance, PlanNode, NodeExecutionState, AgentSpec } from '../../../../../plan/types';
+
+function makeAgentNode(id: string, opts: Partial<PlanNode> & { effort?: string; model?: string } = {}): PlanNode {
+  const work: AgentSpec = {
+    type: 'agent',
+    instructions: 'do work',
+    effort: (opts.effort as any) ?? 'medium',
+    ...(opts.model ? { model: opts.model } : {}),
+  } as AgentSpec;
+  return {
+    id,
+    producerId: opts.producerId ?? id,
+    name: opts.name ?? id,
+    type: 'job',
+    task: opts.task ?? 'do stuff',
+    dependencies: opts.dependencies ?? [],
+    dependents: opts.dependents ?? [],
+    work,
+  } as PlanNode;
+}
+
+function makeShellNode(id: string): PlanNode {
+  return {
+    id,
+    producerId: id,
+    name: id,
+    type: 'job',
+    task: 'shell job',
+    dependencies: [],
+    dependents: [],
+    work: { type: 'shell', command: 'echo hi', shell: 'bash' },
+  } as PlanNode;
+}
+
+function makeState(status: string, extras: Partial<NodeExecutionState> = {}): NodeExecutionState {
+  return { status: status as any, version: 0, attempts: 0, ...extras } as NodeExecutionState;
+}
+
+function makePlan(nodes: PlanNode[], states: Map<string, NodeExecutionState>): PlanInstance {
+  const nodesMap = new Map<string, PlanNode>();
+  const producerMap = new Map<string, string>();
+  for (const n of nodes) {
+    nodesMap.set(n.id, n);
+    if (n.producerId) { producerMap.set(n.producerId, n.id); }
+  }
+  return {
+    id: 'plan-1',
+    spec: {} as any,
+    jobs: nodesMap,
+    producerIdToNodeId: producerMap,
+    roots: [],
+    leaves: [],
+    nodeStates: states,
+    groups: new Map(),
+    groupStates: new Map(),
+    groupPathToId: new Map(),
+    repoPath: '/repo',
+    baseBranch: 'main',
+    worktreeRoot: '/worktrees',
+    createdAt: Date.now(),
+    startedAt: Date.now(),
+    stateVersion: 0,
+    cleanUpSuccessfulWork: false,
+    maxParallel: 4,
+  } as PlanInstance;
+}
+
+function makeCtx(plan: PlanInstance | undefined): any {
+  return {
+    PlanRunner: {
+      getPlan: sinon.stub().returns(plan),
+      get: sinon.stub().returns(plan),
+      savePlan: sinon.stub(),
+      emit: sinon.stub(),
+    },
+    workspacePath: '/test',
+  };
+}
+
+suite('bulkUpdateJobsHandler', () => {
+  let sandbox: sinon.SinonSandbox;
+  setup(() => { sandbox = sinon.createSandbox(); });
+  teardown(() => { sandbox.restore(); });
+
+  test('updates failed jobs (primary use case: update model/effort before retry)', async () => {
+    const failed = makeAgentNode('failed-job', { effort: 'medium' });
+    const plan = makePlan([failed], new Map([['failed-job', makeState('failed', { attempts: 1 })]]));
+    const ctx = makeCtx(plan);
+
+    const result = await handleBulkUpdatePlanJobs({
+      planId: 'plan-1',
+      updates: { model: 'claude-opus-4.6', effort: 'high' },
+    }, ctx);
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.updated, 1);
+    assert.deepStrictEqual(result.updatedJobs, ['failed-job']);
+    const updatedWork = failed.work as AgentSpec;
+    assert.strictEqual(updatedWork.model, 'claude-opus-4.6');
+    assert.strictEqual(updatedWork.effort, 'high');
+  });
+
+  test('updates blocked jobs (so they pick up new spec when unblocked)', async () => {
+    const blocked = makeAgentNode('blocked-job', { effort: 'medium' });
+    const plan = makePlan([blocked], new Map([['blocked-job', makeState('blocked')]]));
+    const ctx = makeCtx(plan);
+
+    const result = await handleBulkUpdatePlanJobs({
+      planId: 'plan-1',
+      updates: { effort: 'high' },
+    }, ctx);
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.updated, 1);
+    assert.strictEqual((blocked.work as AgentSpec).effort, 'high');
+  });
+
+  test('skips running, succeeded, and canceled jobs', async () => {
+    const running = makeAgentNode('running-job');
+    const succeeded = makeAgentNode('succeeded-job');
+    const canceled = makeAgentNode('canceled-job');
+    const states = new Map<string, NodeExecutionState>([
+      ['running-job', makeState('running')],
+      ['succeeded-job', makeState('succeeded')],
+      ['canceled-job', makeState('canceled')],
+    ]);
+    const plan = makePlan([running, succeeded, canceled], states);
+    const ctx = makeCtx(plan);
+
+    const result = await handleBulkUpdatePlanJobs({
+      planId: 'plan-1',
+      updates: { effort: 'high' },
+    }, ctx);
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.updated, 0);
+    assert.strictEqual(result.skipped, 3);
+    const reasons = (result.skippedDetails as { id: string; reason: string }[]).map(s => s.reason).sort();
+    assert.deepStrictEqual(reasons, ['status=canceled', 'status=running', 'status=succeeded']);
+  });
+
+  test('updates pending and ready jobs', async () => {
+    const pending = makeAgentNode('pending-job');
+    const ready = makeAgentNode('ready-job');
+    const plan = makePlan(
+      [pending, ready],
+      new Map([['pending-job', makeState('pending')], ['ready-job', makeState('ready')]]),
+    );
+    const ctx = makeCtx(plan);
+
+    const result = await handleBulkUpdatePlanJobs({
+      planId: 'plan-1',
+      updates: { model: 'claude-opus-4.6' },
+    }, ctx);
+
+    assert.strictEqual(result.updated, 2);
+  });
+
+  test('skips non-agent (shell) work specs', async () => {
+    const shellNode = makeShellNode('shell-job');
+    const plan = makePlan([shellNode], new Map([['shell-job', makeState('failed')]]));
+    const ctx = makeCtx(plan);
+
+    const result = await handleBulkUpdatePlanJobs({
+      planId: 'plan-1',
+      updates: { effort: 'high' },
+    }, ctx);
+
+    assert.strictEqual(result.updated, 0);
+    assert.strictEqual(result.skipped, 1);
+    assert.strictEqual((result.skippedDetails as { id: string; reason: string }[])[0].reason, 'not an agent work spec');
+  });
+
+  test('rejects non-bulk-safe fields', async () => {
+    const node = makeAgentNode('n1');
+    const plan = makePlan([node], new Map([['n1', makeState('failed')]]));
+    const ctx = makeCtx(plan);
+
+    const result = await handleBulkUpdatePlanJobs({
+      planId: 'plan-1',
+      updates: { instructions: 'new instructions' },
+    }, ctx);
+
+    assert.strictEqual(result.success, false);
+    assert.ok(result.error?.includes('cannot be bulk-updated'));
+  });
+
+  test('scopes update to provided jobIds', async () => {
+    const a = makeAgentNode('a', { effort: 'medium' });
+    const b = makeAgentNode('b', { effort: 'medium' });
+    const plan = makePlan(
+      [a, b],
+      new Map([['a', makeState('failed')], ['b', makeState('failed')]]),
+    );
+    const ctx = makeCtx(plan);
+
+    const result = await handleBulkUpdatePlanJobs({
+      planId: 'plan-1',
+      jobIds: ['a'],
+      updates: { effort: 'high' },
+    }, ctx);
+
+    assert.strictEqual(result.updated, 1);
+    assert.strictEqual((a.work as AgentSpec).effort, 'high');
+    assert.strictEqual((b.work as AgentSpec).effort, 'medium');
+  });
+
+  test('skips snapshot-validation node', async () => {
+    const sv = makeAgentNode('sv-id', { producerId: '__snapshot-validation__' });
+    const plan = makePlan([sv], new Map([['sv-id', makeState('failed')]]));
+    const ctx = makeCtx(plan);
+
+    const result = await handleBulkUpdatePlanJobs({
+      planId: 'plan-1',
+      updates: { effort: 'high' },
+    }, ctx);
+
+    assert.strictEqual(result.updated, 0);
+  });
+});

--- a/src/test/unit/plan/executionEngine.unit.test.ts
+++ b/src/test/unit/plan/executionEngine.unit.test.ts
@@ -15,7 +15,7 @@ import { PlanPersistence } from '../../../plan/persistence';
 import { PlanEventEmitter } from '../../../plan/planEvents';
 import { PlanConfigManager } from '../../../plan/configManager';
 import { CopilotCliRunner } from '../../../agent/copilotCliRunner';
-import type { PlanInstance, JobNode, NodeExecutionState, PlanNode, ExecutionContext, JobExecutionResult } from '../../../plan/types';
+import type { PlanInstance, JobNode, NodeExecutionState, PlanNode, ExecutionContext, JobExecutionResult, WorkSpec } from '../../../plan/types';
 import type { ILogger } from '../../../interfaces/ILogger';
 
 function silenceConsole(): { restore: () => void } {
@@ -384,6 +384,62 @@ suite('JobExecutionEngine', () => {
       // Should have entries in history for the failed initial + auto-heal sequence
       assert.ok(ns.attemptHistory);
       assert.ok(ns.attemptHistory!.length >= 2);
+    });
+
+    test('auto-heal swaps to agent on setup-phase worktreeInit shell failure (failedWorkSpec)', async () => {
+      // Regression: setup-phase failures previously inspected node.work (typically
+      // an agent spec), so isNonAgentWork was false and auto-heal never engaged
+      // for deterministic worktreeInit shell failures (NU1504, NU1603, dotnet
+      // restore errors, etc.). The fix passes the failing init spec via
+      // result.failedWorkSpec and the engine prefers that over node.work.
+      const dir = makeTmpDir();
+      const plan = createTestPlan();
+      const node = plan.jobs.get('node-1')! as JobNode;
+      // node.work is an AGENT spec (typical for these jobs)
+      node.work = { type: 'agent', instructions: 'Implement the project' };
+      node.autoHeal = true;
+      const sm = new PlanStateMachine(plan);
+      const log = createMockLogger();
+
+      // The failing spec is a worktreeInit SHELL spec, NOT node.work.
+      const failingInitSpec: WorkSpec = { type: 'shell', command: 'dotnet restore solution.sln' };
+
+      const failResult: JobExecutionResult = {
+        success: false,
+        error: 'Worktree init failed: Exit code 1',
+        failedPhase: 'setup',
+        failedWorkSpec: failingInitSpec, // <-- the new field
+        exitCode: 1,
+        stepStatuses: { 'merge-fi': 'skipped', setup: 'failed' },
+      };
+      const healResult: JobExecutionResult = {
+        success: true,
+        completedCommit: 'heal-commit-12345678901234567890123',
+        stepStatuses: { 'merge-fi': 'skipped', setup: 'success', prechecks: 'success', work: 'success', commit: 'success', postchecks: 'success', 'merge-ri': 'skipped' },
+      };
+      const executeStub = sinon.stub();
+      executeStub.onFirstCall().resolves(failResult);
+      executeStub.onSecondCall().resolves(healResult);
+
+      const state = createEngineState(dir, { execute: executeStub });
+      state.plans.set(plan.id, plan);
+      state.stateMachines.set(plan.id, sm);
+      const mockGit = createMockGitOperations();
+      const nodeManager = new NodeManager(state as any, log, mockGit);
+      const engine = new JobExecutionEngine(state, nodeManager, log, mockGit);
+
+      await engine.executeJobNode(plan, sm, node);
+
+      const ns = plan.nodeStates.get('node-1')!;
+      assert.strictEqual(ns.status, 'succeeded', 'setup-phase auto-heal should recover the node');
+      // Heal budget tracked under 'setup'
+      assert.ok(ns.autoHealAttempted, 'autoHealAttempted should be set');
+      assert.ok(
+        (ns.autoHealAttempted as any).setup,
+        `setup heal budget should be tracked, got: ${JSON.stringify(ns.autoHealAttempted)}`,
+      );
+      // At least 2 invocations of the executor (initial failure + heal)
+      assert.ok(executeStub.callCount >= 2, `executor should be called at least 2x, got ${executeStub.callCount}`);
     });
 
     test('auto-heal failure still results in failed node', async () => {

--- a/src/test/unit/plan/executionEngineCoverage.unit.test.ts
+++ b/src/test/unit/plan/executionEngineCoverage.unit.test.ts
@@ -492,7 +492,7 @@ suite('JobExecutionEngine - Coverage', () => {
       assert.strictEqual(executeStub.callCount, 1);
     });
 
-    test('non-healable phase (merge-fi) does not trigger auto-heal', async () => {
+    test('infrastructure phase (merge-fi) triggers auto-heal as non-agent work', async () => {
       const dir = makeTmpDir();
       const plan = createTestPlan();
       const node = plan.jobs.get('node-1')! as JobNode;
@@ -513,7 +513,8 @@ suite('JobExecutionEngine - Coverage', () => {
       await engine.executeJobNode(plan, sm, node);
 
       assert.strictEqual(plan.nodeStates.get('node-1')!.status, 'failed');
-      assert.strictEqual(executeStub.callCount, 1);
+      // merge-fi is now healable — engine retries up to MAX_AUTO_HEAL_PER_PHASE+1 times
+      assert.ok(executeStub.callCount > 1, `Expected auto-heal retries, got ${executeStub.callCount} call(s)`);
     });
   });
 

--- a/src/test/unit/plan/executor.coverage.unit.test.ts
+++ b/src/test/unit/plan/executor.coverage.unit.test.ts
@@ -996,6 +996,12 @@ suite('DefaultJobExecutor Phase Pipeline', () => {
     assert.strictEqual(result.success, false);
     assert.ok(result.error?.includes('init failed'));
     assert.strictEqual(result.failedPhase, 'setup');
+    // The failing init spec must be propagated so executionEngine's auto-heal
+    // gating can correctly identify it as a non-agent (shell) failure rather
+    // than incorrectly inspecting node.work (which may be an agent spec).
+    assert.ok(result.failedWorkSpec, 'failedWorkSpec should be set on setup failure');
+    assert.strictEqual((result.failedWorkSpec as any).type, 'shell');
+    assert.strictEqual((result.failedWorkSpec as any).command, 'npm ci');
   });
 
   test('applyFailureConfig: applies onFailure settings from work spec', async () => {

--- a/src/test/unit/plan/phases/commitPhase.coverage.unit.test.ts
+++ b/src/test/unit/plan/phases/commitPhase.coverage.unit.test.ts
@@ -488,6 +488,7 @@ suite('CommitPhaseExecutor - Coverage', () => {
       assert.strictEqual(result.success, false);
       assert.ok(result.error?.includes('No work evidence'));
       assert.ok(logInfo.calledWithMatch('did not return a parseable judgment'));
+      assert.strictEqual(result.overrideResumeFromPhase, 'work');
     });
   });
 
@@ -594,6 +595,7 @@ suite('CommitPhaseExecutor - Coverage', () => {
       assert.ok(result.error?.includes('Modify files'));
       assert.ok(result.error?.includes('Create an evidence file'));
       assert.ok(result.error?.includes('Declare expectsNoChanges: true'));
+      assert.strictEqual(result.overrideResumeFromPhase, 'work');
     });
   });
 

--- a/src/test/unit/plan/phases/commitPhase.unit.test.ts
+++ b/src/test/unit/plan/phases/commitPhase.unit.test.ts
@@ -196,6 +196,7 @@ suite('CommitPhaseExecutor', () => {
     const result = await executor.execute(makeCtx({ baseCommit: 'abc123' }));
     assert.strictEqual(result.success, false);
     assert.ok(result.error?.includes('No work evidence'));
+    assert.strictEqual(result.overrideResumeFromPhase, 'work');
   });
 
   test('AI review: legitimate no-changes succeeds', async () => {
@@ -248,6 +249,7 @@ suite('CommitPhaseExecutor', () => {
     }));
     assert.strictEqual(result.success, false);
     assert.ok(result.reviewMetrics);
+    assert.strictEqual(result.overrideResumeFromPhase, 'work');
   });
 
   test('AI review delegation failure falls through', async () => {

--- a/src/test/unit/plan/phases/workPhase.unit.test.ts
+++ b/src/test/unit/plan/phases/workPhase.unit.test.ts
@@ -228,3 +228,357 @@ suite('runAgent (standalone)', () => {
     assert.strictEqual(call.model, 'gpt-5');
   });
 });
+
+suite('runAgent (no-op detector — A1)', () => {
+  // Trick: patch Date.now so the FIRST call (startTime in runAgent) returns
+  // realNow() - 90_000, simulating a 90s elapsed run by the time durationMs
+  // is computed on the second Date.now call.
+  function patchDateNowToOldStart(): () => void {
+    const realNow = Date.now;
+    let firstCall = true;
+    (Date as any).now = () => {
+      if (firstCall) { firstCall = false; return realNow() - 90_000; }
+      return realNow();
+    };
+    return () => { (Date as any).now = realNow; };
+  }
+
+  test('flips success→failure when zero changes after long run and node does not expect no-changes', async () => {
+    const runner = {
+      run: sinon.stub().resolves({
+        success: true,
+        sessionId: 'sess-noop',
+        metrics: { codeChanges: { linesAdded: 0, linesRemoved: 0 } },
+      }),
+    };
+    const ctx = makeCtx({ workSpec: { type: 'agent', instructions: 'do work' } });
+    const restore = patchDateNowToOldStart();
+    try {
+      const result = await runAgent({ type: 'agent', instructions: 'do work' }, ctx, runner as any);
+      assert.strictEqual(result.success, false, 'Expected no-op detection to flip success');
+      assert.ok(result.error?.includes('no-op'), `Expected no-op error message, got: ${result.error}`);
+      assert.strictEqual(result.copilotSessionId, 'sess-noop');
+    } finally { restore(); }
+  });
+
+  test('does NOT trip when node declares expectsNoChanges=true', async () => {
+    const runner = {
+      run: sinon.stub().resolves({
+        success: true,
+        metrics: { codeChanges: { linesAdded: 0, linesRemoved: 0 } },
+      }),
+    };
+    const ctx = makeCtx({
+      node: makeNode({ expectsNoChanges: true } as any),
+      workSpec: { type: 'agent', instructions: 'verify only' },
+    });
+    const restore = patchDateNowToOldStart();
+    try {
+      const result = await runAgent({ type: 'agent', instructions: 'verify only' }, ctx, runner as any);
+      assert.strictEqual(result.success, true, 'expectsNoChanges nodes must not trip the no-op detector');
+    } finally { restore(); }
+  });
+
+  test('does NOT trip when run is shorter than the no-op grace window', async () => {
+    const runner = {
+      run: sinon.stub().resolves({
+        success: true,
+        metrics: { codeChanges: { linesAdded: 0, linesRemoved: 0 } },
+      }),
+    };
+    const ctx = makeCtx({ workSpec: { type: 'agent', instructions: 'fast task' } });
+    // No Date.now patching → run completes well under 60s grace window.
+    const result = await runAgent({ type: 'agent', instructions: 'fast task' }, ctx, runner as any);
+    assert.strictEqual(result.success, true);
+  });
+
+  test('does NOT trip when there are real code changes', async () => {
+    const runner = {
+      run: sinon.stub().resolves({
+        success: true,
+        metrics: { codeChanges: { linesAdded: 50, linesRemoved: 3 } },
+      }),
+    };
+    const ctx = makeCtx({ workSpec: { type: 'agent', instructions: 'real work' } });
+    const restore = patchDateNowToOldStart();
+    try {
+      const result = await runAgent({ type: 'agent', instructions: 'real work' }, ctx, runner as any);
+      assert.strictEqual(result.success, true);
+    } finally { restore(); }
+  });
+
+  test('does NOT trip when stats produced no codeChanges metric', async () => {
+    // If we have no metric to inspect, we can't conclude no-op — fail open (success).
+    const runner = {
+      run: sinon.stub().resolves({ success: true, metrics: {} }),
+    };
+    const ctx = makeCtx({ workSpec: { type: 'agent', instructions: 'work' } });
+    const restore = patchDateNowToOldStart();
+    try {
+      const result = await runAgent({ type: 'agent', instructions: 'work' }, ctx, runner as any);
+      assert.strictEqual(result.success, true);
+    } finally { restore(); }
+  });
+});
+
+suite('runAgent (auto-promote complex jobs — B1)', () => {
+  test('promotes large instructions to high effort', async () => {
+    const runner = { run: sinon.stub().resolves({ success: true }) };
+    const ctx = makeCtx();
+    const bigInstructions = 'x'.repeat(5_000); // > 4 KB threshold
+    await runAgent({ type: 'agent', instructions: bigInstructions }, ctx, runner as any);
+    const call = runner.run.firstCall.args[0];
+    assert.strictEqual(call.effort, 'high', 'Expected effort=high after auto-promotion');
+  });
+
+  test('promotes when instructions list ≥6 file paths', async () => {
+    const runner = { run: sinon.stub().resolves({ success: true }) };
+    const ctx = makeCtx();
+    const filey = `# Job\n\nFiles to create:\n` +
+      `- src/dotnet/Foo/Foo.csproj\n` +
+      `- src/dotnet/Foo/Bar.cs\n` +
+      `- src/dotnet/Foo/Baz.cs\n` +
+      `- src/dotnet/Foo/Qux.cs\n` +
+      `- tests/dotnet/Foo.Tests/Foo.Tests.csproj\n` +
+      `- tests/dotnet/Foo.Tests/FooContractTests.cs\n`;
+    await runAgent({ type: 'agent', instructions: filey }, ctx, runner as any);
+    const call = runner.run.firstCall.args[0];
+    assert.strictEqual(call.effort, 'high', 'Expected effort=high after file-count auto-promotion');
+  });
+
+  test('does NOT promote when model is explicitly set', async () => {
+    const runner = { run: sinon.stub().resolves({ success: true }) };
+    const ctx = makeCtx();
+    const bigInstructions = 'x'.repeat(5_000);
+    await runAgent(
+      { type: 'agent', instructions: bigInstructions, model: 'claude-sonnet-4.6' },
+      ctx, runner as any,
+    );
+    const call = runner.run.firstCall.args[0];
+    assert.strictEqual(call.model, 'claude-sonnet-4.6');
+    assert.strictEqual(call.effort, undefined);
+  });
+
+  test('does NOT promote when modelTier is explicitly set', async () => {
+    const runner = { run: sinon.stub().resolves({ success: true }) };
+    const ctx = makeCtx();
+    const bigInstructions = 'x'.repeat(5_000);
+    await runAgent(
+      { type: 'agent', instructions: bigInstructions, modelTier: 'standard' },
+      ctx, runner as any,
+    );
+    const call = runner.run.firstCall.args[0];
+    assert.strictEqual(call.effort, undefined);
+  });
+
+  test('preserves explicit effort (does not stomp caller choice)', async () => {
+    const runner = { run: sinon.stub().resolves({ success: true }) };
+    const ctx = makeCtx();
+    const bigInstructions = 'x'.repeat(5_000);
+    await runAgent(
+      { type: 'agent', instructions: bigInstructions, effort: 'low' },
+      ctx, runner as any,
+    );
+    const call = runner.run.firstCall.args[0];
+    assert.strictEqual(call.effort, 'low', 'Caller effort must be preserved');
+  });
+
+  test('does NOT promote small simple jobs', async () => {
+    const runner = { run: sinon.stub().resolves({ success: true }) };
+    const ctx = makeCtx();
+    await runAgent({ type: 'agent', instructions: 'do a small thing' }, ctx, runner as any);
+    const call = runner.run.firstCall.args[0];
+    assert.strictEqual(call.effort, undefined);
+  });
+});
+
+suite('runAgent (no-op detector — A1)', () => {
+  test('flips success→failure when zero changes after long run and node does not expect no-changes', async () => {
+    // Long-running agent that produces no commits — the failure mode reported in
+    // CLI v1.0.34 logs (empty assistant turn → end_turn → exit 0).
+    const runner = {
+      run: sinon.stub().callsFake(async () => {
+        // Simulate a 90-second run by stubbing Date.now via the metrics path:
+        // the detector reads `durationMs = Date.now() - startTime`, so we make the
+        // run promise resolve after wall-clock time has advanced. We can't stub
+        // Date.now from outside here without sinon clock interference, so instead
+        // we exploit setStartTime: the ctx records start, and we delay the resolve.
+        await new Promise(r => setTimeout(r, 5));
+        return {
+          success: true,
+          metrics: { codeChanges: { linesAdded: 0, linesRemoved: 0 } },
+          sessionId: 'sess-noop',
+        };
+      }),
+    };
+    // Force the duration check: we substitute setStartTime to record a start time
+    // that is 90s in the past so the detector sees `durationMs >= 60_000`.
+    const recordedStart: number[] = [];
+    const ctx = makeCtx({
+      workSpec: { type: 'agent', instructions: 'do work' },
+      setStartTime: (t: number) => { recordedStart.push(t); },
+    });
+    // Patch Date.now temporarily so startTime gets recorded as 90s ago
+    const realNow = Date.now;
+    let firstCall = true;
+    (Date as any).now = () => {
+      if (firstCall) { firstCall = false; return realNow() - 90_000; }
+      return realNow();
+    };
+    try {
+      const result = await runAgent({ type: 'agent', instructions: 'do work' }, ctx, runner as any);
+      assert.strictEqual(result.success, false, 'Expected no-op detection to flip success');
+      assert.ok(result.error?.includes('no-op'), `Expected no-op error message, got: ${result.error}`);
+      assert.strictEqual(result.copilotSessionId, 'sess-noop');
+    } finally { (Date as any).now = realNow; }
+  });
+
+  test('does NOT trip when node declares expectsNoChanges=true', async () => {
+    const runner = {
+      run: sinon.stub().resolves({
+        success: true,
+        metrics: { codeChanges: { linesAdded: 0, linesRemoved: 0 } },
+      }),
+    };
+    const node = makeNode({ expectsNoChanges: true });
+    const ctx = makeCtx({ node, workSpec: { type: 'agent', instructions: 'verify only' } });
+    const realNow = Date.now;
+    let firstCall = true;
+    (Date as any).now = () => {
+      if (firstCall) { firstCall = false; return realNow() - 90_000; }
+      return realNow();
+    };
+    try {
+      const result = await runAgent({ type: 'agent', instructions: 'verify only' }, ctx, runner as any);
+      assert.strictEqual(result.success, true, 'expectsNoChanges nodes must not trip the no-op detector');
+    } finally { (Date as any).now = realNow; }
+  });
+
+  test('does NOT trip when run is shorter than the no-op grace window', async () => {
+    // Short run with zero changes is fine (e.g. transient denial that still exits 0).
+    const runner = {
+      run: sinon.stub().resolves({
+        success: true,
+        metrics: { codeChanges: { linesAdded: 0, linesRemoved: 0 } },
+      }),
+    };
+    const ctx = makeCtx({ workSpec: { type: 'agent', instructions: 'fast task' } });
+    // No Date.now patching → run completes well under 60s grace window.
+    const result = await runAgent({ type: 'agent', instructions: 'fast task' }, ctx, runner as any);
+    assert.strictEqual(result.success, true);
+  });
+
+  test('does NOT trip when there are real code changes', async () => {
+    const runner = {
+      run: sinon.stub().resolves({
+        success: true,
+        metrics: { codeChanges: { linesAdded: 50, linesRemoved: 3 } },
+      }),
+    };
+    const ctx = makeCtx({ workSpec: { type: 'agent', instructions: 'real work' } });
+    const realNow = Date.now;
+    let firstCall = true;
+    (Date as any).now = () => {
+      if (firstCall) { firstCall = false; return realNow() - 90_000; }
+      return realNow();
+    };
+    try {
+      const result = await runAgent({ type: 'agent', instructions: 'real work' }, ctx, runner as any);
+      assert.strictEqual(result.success, true);
+    } finally { (Date as any).now = realNow; }
+  });
+
+  test('does NOT trip when stats produced no codeChanges metric (compat with older CLI without v1.0.34 parser hits)', async () => {
+    // If we have no metric to inspect, we can't conclude no-op — fail open (success).
+    const runner = {
+      run: sinon.stub().resolves({ success: true, metrics: {} }),
+    };
+    const ctx = makeCtx({ workSpec: { type: 'agent', instructions: 'work' } });
+    const realNow = Date.now;
+    let firstCall = true;
+    (Date as any).now = () => {
+      if (firstCall) { firstCall = false; return realNow() - 90_000; }
+      return realNow();
+    };
+    try {
+      const result = await runAgent({ type: 'agent', instructions: 'work' }, ctx, runner as any);
+      assert.strictEqual(result.success, true);
+    } finally { (Date as any).now = realNow; }
+  });
+});
+
+suite('runAgent (auto-promote complex jobs — B1)', () => {
+  test('promotes large instructions to premium tier + high effort', async () => {
+    const runner = { run: sinon.stub().resolves({ success: true }) };
+    const ctx = makeCtx();
+    const bigInstructions = 'x'.repeat(5_000); // > 4 KB threshold
+    await runAgent({ type: 'agent', instructions: bigInstructions }, ctx, runner as any);
+    // suggestModel may not return a model in test env; verify the *tier* and *effort*
+    // were resolved by inspecting the runner call's `effort` arg.
+    const call = runner.run.firstCall.args[0];
+    assert.strictEqual(call.effort, 'high', 'Expected effort=high after auto-promotion');
+  });
+
+  test('promotes when instructions list ≥6 file paths', async () => {
+    const runner = { run: sinon.stub().resolves({ success: true }) };
+    const ctx = makeCtx();
+    const filey = `# Job\n\nFiles to create:\n` +
+      `- src/dotnet/Foo/Foo.csproj\n` +
+      `- src/dotnet/Foo/Bar.cs\n` +
+      `- src/dotnet/Foo/Baz.cs\n` +
+      `- src/dotnet/Foo/Qux.cs\n` +
+      `- tests/dotnet/Foo.Tests/Foo.Tests.csproj\n` +
+      `- tests/dotnet/Foo.Tests/FooContractTests.cs\n`;
+    await runAgent({ type: 'agent', instructions: filey }, ctx, runner as any);
+    const call = runner.run.firstCall.args[0];
+    assert.strictEqual(call.effort, 'high', 'Expected effort=high after file-count auto-promotion');
+  });
+
+  test('does NOT promote when model is explicitly set', async () => {
+    const runner = { run: sinon.stub().resolves({ success: true }) };
+    const ctx = makeCtx();
+    const bigInstructions = 'x'.repeat(5_000);
+    await runAgent(
+      { type: 'agent', instructions: bigInstructions, model: 'claude-sonnet-4.6' },
+      ctx, runner as any,
+    );
+    const call = runner.run.firstCall.args[0];
+    // Explicit model wins; no effort injected.
+    assert.strictEqual(call.model, 'claude-sonnet-4.6');
+    assert.strictEqual(call.effort, undefined);
+  });
+
+  test('does NOT promote when modelTier is explicitly set', async () => {
+    const runner = { run: sinon.stub().resolves({ success: true }) };
+    const ctx = makeCtx();
+    const bigInstructions = 'x'.repeat(5_000);
+    await runAgent(
+      { type: 'agent', instructions: bigInstructions, modelTier: 'standard' },
+      ctx, runner as any,
+    );
+    const call = runner.run.firstCall.args[0];
+    assert.strictEqual(call.effort, undefined);
+  });
+
+  test('preserves explicit effort (does not downgrade when explicit)', async () => {
+    const runner = { run: sinon.stub().resolves({ success: true }) };
+    const ctx = makeCtx();
+    const bigInstructions = 'x'.repeat(5_000);
+    // Caller asked for low; auto-promote should still upgrade (no explicit model/tier),
+    // but should not stomp the caller's effort choice.
+    await runAgent(
+      { type: 'agent', instructions: bigInstructions, effort: 'low' },
+      ctx, runner as any,
+    );
+    const call = runner.run.firstCall.args[0];
+    assert.strictEqual(call.effort, 'low', 'Caller effort must be preserved');
+  });
+
+  test('does NOT promote small simple jobs', async () => {
+    const runner = { run: sinon.stub().resolves({ success: true }) };
+    const ctx = makeCtx();
+    await runAgent({ type: 'agent', instructions: 'do a small thing' }, ctx, runner as any);
+    const call = runner.run.firstCall.args[0];
+    assert.strictEqual(call.effort, undefined);
+  });
+});

--- a/src/test/unit/plan/phases/workPhase.unit.test.ts
+++ b/src/test/unit/plan/phases/workPhase.unit.test.ts
@@ -322,6 +322,17 @@ suite('runAgent (no-op detector — A1)', () => {
 });
 
 suite('runAgent (auto-promote complex jobs — B1)', () => {
+  let effortStub: sinon.SinonStub;
+
+  setup(async () => {
+    const modelDiscovery = await import('../../../../agent/modelDiscovery');
+    effortStub = sinon.stub(modelDiscovery, 'hasEffortSupport').resolves(true);
+  });
+
+  teardown(() => {
+    effortStub?.restore();
+  });
+
   test('promotes large instructions to high effort', async () => {
     const runner = { run: sinon.stub().resolves({ success: true }) };
     const ctx = makeCtx();
@@ -375,197 +386,6 @@ suite('runAgent (auto-promote complex jobs — B1)', () => {
     const runner = { run: sinon.stub().resolves({ success: true }) };
     const ctx = makeCtx();
     const bigInstructions = 'x'.repeat(5_000);
-    await runAgent(
-      { type: 'agent', instructions: bigInstructions, effort: 'low' },
-      ctx, runner as any,
-    );
-    const call = runner.run.firstCall.args[0];
-    assert.strictEqual(call.effort, 'low', 'Caller effort must be preserved');
-  });
-
-  test('does NOT promote small simple jobs', async () => {
-    const runner = { run: sinon.stub().resolves({ success: true }) };
-    const ctx = makeCtx();
-    await runAgent({ type: 'agent', instructions: 'do a small thing' }, ctx, runner as any);
-    const call = runner.run.firstCall.args[0];
-    assert.strictEqual(call.effort, undefined);
-  });
-});
-
-suite('runAgent (no-op detector — A1)', () => {
-  test('flips success→failure when zero changes after long run and node does not expect no-changes', async () => {
-    // Long-running agent that produces no commits — the failure mode reported in
-    // CLI v1.0.34 logs (empty assistant turn → end_turn → exit 0).
-    const runner = {
-      run: sinon.stub().callsFake(async () => {
-        // Simulate a 90-second run by stubbing Date.now via the metrics path:
-        // the detector reads `durationMs = Date.now() - startTime`, so we make the
-        // run promise resolve after wall-clock time has advanced. We can't stub
-        // Date.now from outside here without sinon clock interference, so instead
-        // we exploit setStartTime: the ctx records start, and we delay the resolve.
-        await new Promise(r => setTimeout(r, 5));
-        return {
-          success: true,
-          metrics: { codeChanges: { linesAdded: 0, linesRemoved: 0 } },
-          sessionId: 'sess-noop',
-        };
-      }),
-    };
-    // Force the duration check: we substitute setStartTime to record a start time
-    // that is 90s in the past so the detector sees `durationMs >= 60_000`.
-    const recordedStart: number[] = [];
-    const ctx = makeCtx({
-      workSpec: { type: 'agent', instructions: 'do work' },
-      setStartTime: (t: number) => { recordedStart.push(t); },
-    });
-    // Patch Date.now temporarily so startTime gets recorded as 90s ago
-    const realNow = Date.now;
-    let firstCall = true;
-    (Date as any).now = () => {
-      if (firstCall) { firstCall = false; return realNow() - 90_000; }
-      return realNow();
-    };
-    try {
-      const result = await runAgent({ type: 'agent', instructions: 'do work' }, ctx, runner as any);
-      assert.strictEqual(result.success, false, 'Expected no-op detection to flip success');
-      assert.ok(result.error?.includes('no-op'), `Expected no-op error message, got: ${result.error}`);
-      assert.strictEqual(result.copilotSessionId, 'sess-noop');
-    } finally { (Date as any).now = realNow; }
-  });
-
-  test('does NOT trip when node declares expectsNoChanges=true', async () => {
-    const runner = {
-      run: sinon.stub().resolves({
-        success: true,
-        metrics: { codeChanges: { linesAdded: 0, linesRemoved: 0 } },
-      }),
-    };
-    const node = makeNode({ expectsNoChanges: true });
-    const ctx = makeCtx({ node, workSpec: { type: 'agent', instructions: 'verify only' } });
-    const realNow = Date.now;
-    let firstCall = true;
-    (Date as any).now = () => {
-      if (firstCall) { firstCall = false; return realNow() - 90_000; }
-      return realNow();
-    };
-    try {
-      const result = await runAgent({ type: 'agent', instructions: 'verify only' }, ctx, runner as any);
-      assert.strictEqual(result.success, true, 'expectsNoChanges nodes must not trip the no-op detector');
-    } finally { (Date as any).now = realNow; }
-  });
-
-  test('does NOT trip when run is shorter than the no-op grace window', async () => {
-    // Short run with zero changes is fine (e.g. transient denial that still exits 0).
-    const runner = {
-      run: sinon.stub().resolves({
-        success: true,
-        metrics: { codeChanges: { linesAdded: 0, linesRemoved: 0 } },
-      }),
-    };
-    const ctx = makeCtx({ workSpec: { type: 'agent', instructions: 'fast task' } });
-    // No Date.now patching → run completes well under 60s grace window.
-    const result = await runAgent({ type: 'agent', instructions: 'fast task' }, ctx, runner as any);
-    assert.strictEqual(result.success, true);
-  });
-
-  test('does NOT trip when there are real code changes', async () => {
-    const runner = {
-      run: sinon.stub().resolves({
-        success: true,
-        metrics: { codeChanges: { linesAdded: 50, linesRemoved: 3 } },
-      }),
-    };
-    const ctx = makeCtx({ workSpec: { type: 'agent', instructions: 'real work' } });
-    const realNow = Date.now;
-    let firstCall = true;
-    (Date as any).now = () => {
-      if (firstCall) { firstCall = false; return realNow() - 90_000; }
-      return realNow();
-    };
-    try {
-      const result = await runAgent({ type: 'agent', instructions: 'real work' }, ctx, runner as any);
-      assert.strictEqual(result.success, true);
-    } finally { (Date as any).now = realNow; }
-  });
-
-  test('does NOT trip when stats produced no codeChanges metric (compat with older CLI without v1.0.34 parser hits)', async () => {
-    // If we have no metric to inspect, we can't conclude no-op — fail open (success).
-    const runner = {
-      run: sinon.stub().resolves({ success: true, metrics: {} }),
-    };
-    const ctx = makeCtx({ workSpec: { type: 'agent', instructions: 'work' } });
-    const realNow = Date.now;
-    let firstCall = true;
-    (Date as any).now = () => {
-      if (firstCall) { firstCall = false; return realNow() - 90_000; }
-      return realNow();
-    };
-    try {
-      const result = await runAgent({ type: 'agent', instructions: 'work' }, ctx, runner as any);
-      assert.strictEqual(result.success, true);
-    } finally { (Date as any).now = realNow; }
-  });
-});
-
-suite('runAgent (auto-promote complex jobs — B1)', () => {
-  test('promotes large instructions to premium tier + high effort', async () => {
-    const runner = { run: sinon.stub().resolves({ success: true }) };
-    const ctx = makeCtx();
-    const bigInstructions = 'x'.repeat(5_000); // > 4 KB threshold
-    await runAgent({ type: 'agent', instructions: bigInstructions }, ctx, runner as any);
-    // suggestModel may not return a model in test env; verify the *tier* and *effort*
-    // were resolved by inspecting the runner call's `effort` arg.
-    const call = runner.run.firstCall.args[0];
-    assert.strictEqual(call.effort, 'high', 'Expected effort=high after auto-promotion');
-  });
-
-  test('promotes when instructions list ≥6 file paths', async () => {
-    const runner = { run: sinon.stub().resolves({ success: true }) };
-    const ctx = makeCtx();
-    const filey = `# Job\n\nFiles to create:\n` +
-      `- src/dotnet/Foo/Foo.csproj\n` +
-      `- src/dotnet/Foo/Bar.cs\n` +
-      `- src/dotnet/Foo/Baz.cs\n` +
-      `- src/dotnet/Foo/Qux.cs\n` +
-      `- tests/dotnet/Foo.Tests/Foo.Tests.csproj\n` +
-      `- tests/dotnet/Foo.Tests/FooContractTests.cs\n`;
-    await runAgent({ type: 'agent', instructions: filey }, ctx, runner as any);
-    const call = runner.run.firstCall.args[0];
-    assert.strictEqual(call.effort, 'high', 'Expected effort=high after file-count auto-promotion');
-  });
-
-  test('does NOT promote when model is explicitly set', async () => {
-    const runner = { run: sinon.stub().resolves({ success: true }) };
-    const ctx = makeCtx();
-    const bigInstructions = 'x'.repeat(5_000);
-    await runAgent(
-      { type: 'agent', instructions: bigInstructions, model: 'claude-sonnet-4.6' },
-      ctx, runner as any,
-    );
-    const call = runner.run.firstCall.args[0];
-    // Explicit model wins; no effort injected.
-    assert.strictEqual(call.model, 'claude-sonnet-4.6');
-    assert.strictEqual(call.effort, undefined);
-  });
-
-  test('does NOT promote when modelTier is explicitly set', async () => {
-    const runner = { run: sinon.stub().resolves({ success: true }) };
-    const ctx = makeCtx();
-    const bigInstructions = 'x'.repeat(5_000);
-    await runAgent(
-      { type: 'agent', instructions: bigInstructions, modelTier: 'standard' },
-      ctx, runner as any,
-    );
-    const call = runner.run.firstCall.args[0];
-    assert.strictEqual(call.effort, undefined);
-  });
-
-  test('preserves explicit effort (does not downgrade when explicit)', async () => {
-    const runner = { run: sinon.stub().resolves({ success: true }) };
-    const ctx = makeCtx();
-    const bigInstructions = 'x'.repeat(5_000);
-    // Caller asked for low; auto-promote should still upgrade (no explicit model/tier),
-    // but should not stomp the caller's effort choice.
     await runAgent(
       { type: 'agent', instructions: bigInstructions, effort: 'low' },
       ctx, runner as any,


### PR DESCRIPTION
## Summary

Two related fixes that surfaced during a real plan execution today, plus additional improvements found during review feedback resolution.

### 1. Auto-heal gating bug for setup-phase shell failures

When a worktreeInit shell spec failed during the setup phase, the auto-heal gate in executionEngine.ts inspected node.work (typically an agent spec), so:

- isNonAgentWork evaluated to false (because node.work.type === 'agent')
- Deterministic exit code 1 is not an external kill, so wasExternallyKilled was also false
- **Result**: auto-heal was skipped even though the failure was a simple shell init problem

**Fix**: Add failedWorkSpec to JobExecutionResult and populate it for worktreeInit failures so auto-heal correctly classifies setup-phase failures.

### 2. Context-pressure gating

contextPressure behavior was partially active even when the feature flag was disabled. **Fix**: Gate global checkpoint-manager registration behind copilotOrchestrator.contextPressure.enabled.

### 3. Make merge-fi auto-healable

Forward integration merge failures were not eligible for auto-heal (merge-fi was missing from the isHealablePhase allowlist). Additionally, the git merge conflict detector only checked for the literal word CONFLICT - when a retry attempt hit pre-existing unmerged files ('Merging is not possible because you have unmerged files'), it was classified as a generic failure, bypassing the AI conflict resolution path entirely.

**Fix**: Add merge-fi to healable phases, add isInfrastructurePhase gate for phases with no work spec, and expand conflict detection to recognize 'unmerged files' errors.

### 4. Work-phase no-op exit detector (new behavior)

Adds detection for agent runs that report success but produce zero code changes after a long run (>=60s). This catches the failure mode where the CLI exits 0 with an empty assistant turn. The detector flips the result to failure so auto-heal can retry.

- **Opt-out**: Set expectsNoChanges: true on the node spec
- **Grace window**: Runs shorter than 60s are not flagged
- **Fail-open**: If no codeChanges metric is available, success is preserved

### 5. Work-phase auto-promote for complex jobs

Jobs with large instructions (>=4KB) or many file paths (>=6) are automatically promoted to effort: 'high' unless the spec already has an explicit model, modelTier, or effort set.

### 6. Commit-phase no-evidence auto-heal

When commit phase fails with 'no work evidence' and the AI review says the agent should have made changes, the phase now returns overrideResumeFromPhase='work' so the engine retries from the work phase.

### 7. Review feedback fixes

- instrBytes now uses Buffer.byteLength() for accurate UTF-8 byte count
- Removed duplicate test suites in workPhase tests
- Fixed initializePlanRunner test to pass required git and debouncer args
- tmpWorkspace in planInitialization tests moved to setup/teardown for cleanup
- Bulk job update MCP handler with tests